### PR TITLE
Automate certification & introduce basic structure

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,40 @@
+PATH
+  remote: .
+  specs:
+    vantiv-ruby (0.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.1)
+    diff-lcs (1.2.5)
+    method_source (0.8.2)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.3)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+    slop (3.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pry
+  rspec
+  vantiv-ruby!
+
+BUNDLED WITH
+   1.11.0

--- a/bin/vantiv-certify-app
+++ b/bin/vantiv-certify-app
@@ -1,0 +1,90 @@
+#!/usr/bin/env ruby
+require 'vantiv-ruby'
+require 'pry'
+
+unless ENV['ACCEPTOR_ID'] && ENV['APP_ID'] && ENV['LICENSE_ID']
+  raise "License ID, Acceptor ID and Application ID required"
+end
+
+Vantiv.configure do |config|
+  config.license_id = ENV["LICENSE_ID"]
+  config.acceptor_id = ENV["ACCEPTOR_ID"]
+  config.application_id = ENV["APP_ID"]
+
+  config.default_report_group = '1'
+end
+
+fixtures = Dir.glob("#{Vantiv.root}/cert_fixtures/**/*")
+
+results_file = File.open("certs.txt", "w")
+
+class ResponseCache
+  def initialize
+    @responses = {}
+  end
+
+  def push(cert_name, response)
+    responses[cert_name] = response
+  end
+
+  def access_value(values_tree)
+    cert_name = values_tree.shift
+    response_body = responses[cert_name].body
+
+    get_value(response_body, values_tree)
+  end
+
+  private
+
+  attr_reader :responses
+
+  def get_value(source, keys)
+    keys.any? ? get_value(source[keys.shift], keys) : source
+  end
+end
+
+def sub_values(string, response_cache)
+  if matches = /.*\#\{(.*)\}.*/.match(string)
+    matches = matches.to_a
+    matches.shift
+    matches.each do |match|
+      string = string.gsub(
+        /\#\{#{match}\}/,
+        response_cache.access_value(match.split("."))
+      )
+    end
+    string
+  else
+    string
+  end
+end
+
+def dup_and_sub(hash, response_cache)
+  dup = {}
+  hash.each do |key, value|
+    if value.is_a?(Hash)
+      dup[key] = dup_and_sub(value, response_cache)
+    else
+      dup[key] = sub_values(value, response_cache)
+    end
+  end
+  dup
+end
+
+response_cache = ResponseCache.new
+
+fixtures.each do |file_name|
+  cert_name = /.*\/cert_fixtures\/(\w*).json/.match(file_name)[1]
+  contents = JSON.parse(File.read(file_name))
+  endpoint = contents["endpoint"]
+  body = dup_and_sub(contents["body"], response_cache)
+
+  response = Vantiv.send(endpoint, body)
+
+  response_cache.push(cert_name, response)
+
+  results_file << "#{cert_name},#{response.request_id}\n"
+end
+
+results_file.close
+%x(open certs.txt)

--- a/cert_fixtures/L_AC_1.json
+++ b/cert_fixtures/L_AC_1.json
@@ -1,0 +1,27 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4457010000000009",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16",
+      "CVV": "349"
+    },
+    "Address": {
+      "BillingName": "John & Mary Smith",
+      "BillingAddress1": "1 Main St.",
+      "BillingCity": "Burlington",
+      "BillingState": "MA",
+      "BillingZipcode": "01803-3747",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_1A.json
+++ b/cert_fixtures/L_AC_1A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AC_1.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_2.json
+++ b/cert_fixtures/L_AC_2.json
@@ -1,0 +1,30 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5112010000000003",
+      "ExpirationMonth": "02",
+      "ExpirationYear": "16",
+      "CVV": "261"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Mike J. Hammer",
+      "BillingAddress1": "2 Main St.",
+      "BillingAddress2": "Apt. 222",
+      "BillingCity": "Riverside",
+      "BillingState": "RI",
+      "BillingZipcode": "02915",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_2A.json
+++ b/cert_fixtures/L_AC_2A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AC_2.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_3.json
+++ b/cert_fixtures/L_AC_3.json
@@ -1,0 +1,29 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "DI",
+      "CardNumber": "6011010000000003",
+      "ExpirationMonth": "03",
+      "ExpirationYear": "16",
+      "CVV": "758"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Eileen Jones",
+      "BillingAddress1": "3 Main St.",
+      "BillingCity": "Bloomfield",
+      "BillingState": "CT",
+      "BillingZipcode": "06002",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_3A.json
+++ b/cert_fixtures/L_AC_3A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AC_3.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_4.json
+++ b/cert_fixtures/L_AC_4.json
@@ -1,0 +1,28 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "AX",
+      "CardNumber": "375001000000005",
+      "ExpirationMonth": "04",
+      "ExpirationYear": "16"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Bob Black",
+      "BillingAddress1": "4 Main St.",
+      "BillingCity": "Laurel",
+      "BillingState": "MD",
+      "BillingZipcode": "20708",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_4A.json
+++ b/cert_fixtures/L_AC_4A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AC_4.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_5.json
+++ b/cert_fixtures/L_AC_5.json
@@ -1,0 +1,21 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4100200300011001",
+      "ExpirationMonth": "05",
+      "ExpirationYear": "16",
+      "CVV": "463"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    }
+  }
+}

--- a/cert_fixtures/L_AC_5A.json
+++ b/cert_fixtures/L_AC_5A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AC_5.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_6.json
+++ b/cert_fixtures/L_AC_6.json
@@ -1,0 +1,27 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4457010100000008",
+      "ExpirationMonth": "06",
+      "ExpirationYear": "16",
+      "CVV": "992"
+    },
+    "Address": {
+      "BillingName": "Joe Green",
+      "BillingAddress1": "6 Main St.",
+      "BillingCity": "Derry",
+      "BillingState": "NH",
+      "BillingZipcode": "03038",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_7.json
+++ b/cert_fixtures/L_AC_7.json
@@ -1,0 +1,26 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5112010100000002",
+      "ExpirationMonth": "07",
+      "ExpirationYear": "16",
+      "CVV": "251"
+    },
+    "Address": {
+      "BillingName": "Jane Murray",
+      "BillingAddress1": "7 Main St.",
+      "BillingCity": "Amesbury",
+      "BillingState": "MA",
+      "BillingZipcode": "01913",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_8.json
+++ b/cert_fixtures/L_AC_8.json
@@ -1,0 +1,26 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "DI",
+      "CardNumber": "6011010100000002",
+      "ExpirationMonth": "08",
+      "ExpirationYear": "16",
+      "CVV": "184"
+    },
+    "Address": {
+      "BillingName": "Mark Johnson",
+      "BillingAddress1": "8 Main St.",
+      "BillingCity": "Manchester",
+      "BillingState": "NH",
+      "BillingZipcode": "03101",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AC_9.json
+++ b/cert_fixtures/L_AC_9.json
@@ -1,0 +1,26 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "AX",
+      "CardNumber": "375001010000003",
+      "ExpirationMonth": "09",
+      "ExpirationYear": "16",
+      "CVV": "0421"
+    },
+    "Address": {
+      "BillingName": "James Miller",
+      "BillingAddress1": "9 Main St.",
+      "BillingCity": "Boston",
+      "BillingState": "MA",
+      "BillingZipcode": "02134",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_1.json
+++ b/cert_fixtures/L_AR_1.json
@@ -1,0 +1,27 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "100.10",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4457010000000009",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16",
+      "CVV": "349"
+    },
+    "Address": {
+      "BillingName": "John Smith",
+      "BillingAddress1": "1 Main St.",
+      "BillingCity": "Burlington",
+      "BillingState": "MA",
+      "BillingZipcode": "01803-3747",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_1A.json
+++ b/cert_fixtures/L_AR_1A.json
@@ -1,0 +1,9 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AR_1.litleOnlineResponse.authorizationResponse.TransactionID}",
+      "TransactionAmount": "50.50"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_1B.json
+++ b/cert_fixtures/L_AR_1B.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "auth_reversal",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AR_1.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_2.json
+++ b/cert_fixtures/L_AR_2.json
@@ -1,0 +1,30 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "200.20",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5112010000000003",
+      "ExpirationMonth": "02",
+      "ExpirationYear": "16",
+      "CVV": "261"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Mike J. Hammer",
+      "BillingAddress1": "2 Main St.",
+      "BillingAddress2": "Apt. 222",
+      "BillingCity": "Riverside",
+      "BillingState": "RI",
+      "BillingZipcode": "02915",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_2A.json
+++ b/cert_fixtures/L_AR_2A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "auth_reversal",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AR_2.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_3.json
+++ b/cert_fixtures/L_AR_3.json
@@ -1,0 +1,29 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "300.30",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "DI",
+      "CardNumber": "6011010000000003",
+      "ExpirationMonth": "03",
+      "ExpirationYear": "16",
+      "CVV": "758"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Eileen Jones",
+      "BillingAddress1": "3 Main St.",
+      "BillingCity": "Bloomfield",
+      "BillingState": "CT",
+      "BillingZipcode": "06002",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_3A.json
+++ b/cert_fixtures/L_AR_3A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "auth_reversal",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AR_3.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_4.json
+++ b/cert_fixtures/L_AR_4.json
@@ -1,0 +1,25 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "AX",
+      "CardNumber": "375001000000005",
+      "ExpirationMonth": "04",
+      "ExpirationYear": "16"
+    },
+    "Address": {
+      "BillingName": "Bob Black",
+      "BillingAddress1": "4 Main St.",
+      "BillingCity": "Laurel",
+      "BillingState": "MD",
+      "BillingZipcode": "20708",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_4A.json
+++ b/cert_fixtures/L_AR_4A.json
@@ -1,0 +1,9 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AR_4.litleOnlineResponse.authorizationResponse.TransactionID}",
+      "TransactionAmount": "50.50"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_4B.json
+++ b/cert_fixtures/L_AR_4B.json
@@ -1,0 +1,9 @@
+{
+  "endpoint": "auth_reversal",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AR_4.litleOnlineResponse.authorizationResponse.TransactionID}",
+      "TransactionAmount": "50.50"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_5.json
+++ b/cert_fixtures/L_AR_5.json
@@ -1,0 +1,17 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "205.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "AX",
+      "CardNumber": "375000026600004",
+      "ExpirationMonth": "05",
+      "ExpirationYear": "16"
+    }
+  }
+}

--- a/cert_fixtures/L_AR_5A.json
+++ b/cert_fixtures/L_AR_5A.json
@@ -1,0 +1,9 @@
+{
+  "endpoint": "auth_reversal",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_AR_5.litleOnlineResponse.authorizationResponse.TransactionID}",
+      "TransactionAmount": "100.00"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_1.json
+++ b/cert_fixtures/L_RC_1.json
@@ -1,0 +1,27 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4457010000000009",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16",
+      "CVV": "349"
+    },
+    "Address": {
+      "BillingName": "John & Mary Smith",
+      "BillingAddress1": "1 Main St.",
+      "BillingCity": "Burlington",
+      "BillingState": "MA",
+      "BillingZipcode": "01803-3747",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_1A.json
+++ b/cert_fixtures/L_RC_1A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_1.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_1B.json
+++ b/cert_fixtures/L_RC_1B.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "credit",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_1A.litleOnlineResponse.captureResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_2.json
+++ b/cert_fixtures/L_RC_2.json
@@ -1,0 +1,30 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5112010000000003",
+      "ExpirationMonth": "02",
+      "ExpirationYear": "16",
+      "CVV": "261"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Mike J. Hammer",
+      "BillingAddress1": "2 Main St.",
+      "BillingAddress2": "Apt. 222",
+      "BillingCity": "Riverside",
+      "BillingState": "RI",
+      "BillingZipcode": "02915",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_2A.json
+++ b/cert_fixtures/L_RC_2A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_2.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_2B.json
+++ b/cert_fixtures/L_RC_2B.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "credit",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_2A.litleOnlineResponse.captureResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_3.json
+++ b/cert_fixtures/L_RC_3.json
@@ -1,0 +1,29 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "DI",
+      "CardNumber": "6011010000000003",
+      "ExpirationMonth": "03",
+      "ExpirationYear": "16",
+      "CVV": "758"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Eileen Jones",
+      "BillingAddress1": "3 Main St.",
+      "BillingCity": "Bloomfield",
+      "BillingState": "CT",
+      "BillingZipcode": "06002",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_3A.json
+++ b/cert_fixtures/L_RC_3A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_3.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_3B.json
+++ b/cert_fixtures/L_RC_3B.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "credit",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_3A.litleOnlineResponse.captureResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_4.json
+++ b/cert_fixtures/L_RC_4.json
@@ -1,0 +1,28 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "AX",
+      "CardNumber": "375001000000005",
+      "ExpirationMonth": "04",
+      "ExpirationYear": "16"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Bob Black",
+      "BillingAddress1": "4 Main St.",
+      "BillingCity": "Laurel",
+      "BillingState": "MD",
+      "BillingZipcode": "20708",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_4A.json
+++ b/cert_fixtures/L_RC_4A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_4.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_4B.json
+++ b/cert_fixtures/L_RC_4B.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "credit",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_4A.litleOnlineResponse.captureResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_5.json
+++ b/cert_fixtures/L_RC_5.json
@@ -1,0 +1,21 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4100200300011001",
+      "ExpirationMonth": "05",
+      "ExpirationYear": "16",
+      "CVV": "463"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    }
+  }
+}

--- a/cert_fixtures/L_RC_5A.json
+++ b/cert_fixtures/L_RC_5A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_5.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_5B.json
+++ b/cert_fixtures/L_RC_5B.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "credit",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_5A.litleOnlineResponse.captureResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_6.json
+++ b/cert_fixtures/L_RC_6.json
@@ -1,0 +1,27 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4457010000000009",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16",
+      "CVV": "349"
+    },
+    "Address": {
+      "BillingName": "John & Mary Smith",
+      "BillingAddress1": "1 Main St.",
+      "BillingCity": "Burlington",
+      "BillingState": "MA",
+      "BillingZipcode": "01803-3747",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_6A.json
+++ b/cert_fixtures/L_RC_6A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "credit",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_6.litleOnlineResponse.saleResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_7.json
+++ b/cert_fixtures/L_RC_7.json
@@ -1,0 +1,26 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5112010000000003",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16",
+      "CVV": "349"
+    },
+    "Address": {
+      "BillingName": "John & Mary Smith",
+      "BillingAddress1": "1 Main St.",
+      "BillingCity": "Burlington",
+      "BillingState": "MA",
+      "BillingZipcode": "01803-3747",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_7A.json
+++ b/cert_fixtures/L_RC_7A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "credit",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_RC_7.litleOnlineResponse.saleResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_RC_8.json
+++ b/cert_fixtures/L_RC_8.json
@@ -1,0 +1,18 @@
+{
+  "endpoint": "return",
+  "body": {
+    "Transaction": {
+      "TransactionAmount": "101.00",
+      "ReferenceNumber": "12345",
+      "OrderSource": "ecommerce",
+      "CustomerID": "123"
+    },
+    "Card": {
+      "CardNumber": "4457010000000009",
+      "CVV": "349",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16",
+      "Type": "VI"
+    }
+  }
+}

--- a/cert_fixtures/L_S_1.json
+++ b/cert_fixtures/L_S_1.json
@@ -1,0 +1,27 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4457010000000009",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16",
+      "CVV": "349"
+    },
+    "Address": {
+      "BillingName": "John & Mary Smith",
+      "BillingAddress1": "1 Main St.",
+      "BillingCity": "Burlington",
+      "BillingState": "MA",
+      "BillingZipcode": "01803-3747",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_S_2.json
+++ b/cert_fixtures/L_S_2.json
@@ -1,0 +1,30 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5112010000000003",
+      "ExpirationMonth": "02",
+      "ExpirationYear": "16",
+      "CVV": "261"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Mike J. Hammer",
+      "BillingAddress1": "2 Main St.",
+      "BillingAddress2": "Apt. 222",
+      "BillingCity": "Riverside",
+      "BillingState": "RI",
+      "BillingZipcode": "02915",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_S_3.json
+++ b/cert_fixtures/L_S_3.json
@@ -1,0 +1,26 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "DI",
+      "CardNumber": "6011010000000003",
+      "ExpirationMonth": "03",
+      "ExpirationYear": "16",
+      "CVV": "758"
+    },
+    "Address": {
+      "BillingName": "Eileen Jones",
+      "BillingAddress1": "3 Main St.",
+      "BillingCity": "Bloomfield",
+      "BillingState": "CT",
+      "BillingZipcode": "06002",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_S_4.json
+++ b/cert_fixtures/L_S_4.json
@@ -1,0 +1,28 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "AX",
+      "CardNumber": "375001000000005",
+      "ExpirationMonth": "04",
+      "ExpirationYear": "16"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Bob Black",
+      "BillingAddress1": "4 Main St.",
+      "BillingCity": "Laurel",
+      "BillingState": "MD",
+      "BillingZipcode": "20708",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_S_5.json
+++ b/cert_fixtures/L_S_5.json
@@ -1,0 +1,21 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4100200300011001",
+      "ExpirationMonth": "05",
+      "ExpirationYear": "16",
+      "CVV": "463"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    }
+  }
+}

--- a/cert_fixtures/L_S_6.json
+++ b/cert_fixtures/L_S_6.json
@@ -1,0 +1,26 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4457010100000008",
+      "ExpirationMonth": "06",
+      "ExpirationYear": "16",
+      "CVV": "992"
+    },
+    "Address": {
+      "BillingName": "Joe Green",
+      "BillingAddress1": "6 Main St.",
+      "BillingCity": "Derry",
+      "BillingState": "NH",
+      "BillingZipcode": "03038",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_S_7.json
+++ b/cert_fixtures/L_S_7.json
@@ -1,0 +1,26 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5112010100000002",
+      "ExpirationMonth": "07",
+      "ExpirationYear": "16",
+      "CVV": "251"
+    },
+    "Address": {
+      "BillingName": "Jane Murray",
+      "BillingAddress1": "7 Main St.",
+      "BillingCity": "Amesbury",
+      "BillingState": "MA",
+      "BillingZipcode": "01913",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_S_8.json
+++ b/cert_fixtures/L_S_8.json
@@ -1,0 +1,26 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "DI",
+      "CardNumber": "6011010100000002",
+      "ExpirationMonth": "08",
+      "ExpirationYear": "16",
+      "CVV": "184"
+    },
+    "Address": {
+      "BillingName": "Mark Johnson",
+      "BillingAddress1": "8 Main St.",
+      "BillingCity": "Manchester",
+      "BillingState": "NH",
+      "BillingZipcode": "03101",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_S_9.json
+++ b/cert_fixtures/L_S_9.json
@@ -1,0 +1,26 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "AX",
+      "CardNumber": "375001010000003",
+      "ExpirationMonth": "09",
+      "ExpirationYear": "16",
+      "CVV": "0421"
+    },
+    "Address": {
+      "BillingName": "James Miller",
+      "BillingAddress1": "9 Main St.",
+      "BillingCity": "Boston",
+      "BillingState": "MA",
+      "BillingZipcode": "02134",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_V_1.json
+++ b/cert_fixtures/L_V_1.json
@@ -1,0 +1,27 @@
+{
+  "endpoint": "auth",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4457010000000009",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16",
+      "CVV": "349"
+    },
+    "Address": {
+      "BillingName": "John & Mary Smith",
+      "BillingAddress1": "1 Main St.",
+      "BillingCity": "Burlington",
+      "BillingState": "MA",
+      "BillingZipcode": "01803-3747",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_V_1A.json
+++ b/cert_fixtures/L_V_1A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "capture",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_V_1.litleOnlineResponse.authorizationResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_V_1B.json
+++ b/cert_fixtures/L_V_1B.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "credit",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_V_1A.litleOnlineResponse.captureResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_V_1C.json
+++ b/cert_fixtures/L_V_1C.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "void",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_V_1B.litleOnlineResponse.creditResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_V_2.json
+++ b/cert_fixtures/L_V_2.json
@@ -1,0 +1,30 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5112010000000003",
+      "ExpirationMonth": "02",
+      "ExpirationYear": "16",
+      "CVV": "261"
+    },
+    "CardholderAuthentication": {
+      "AuthenticationValue": "BwABBJQ1AgAAAAAgJDUCAAAAAAA="
+    },
+    "Address": {
+      "BillingName": "Mike J. Hammer",
+      "BillingAddress1": "2 Main St.",
+      "BillingAddress2": "Apt. 222",
+      "BillingCity": "Riverside",
+      "BillingState": "RI",
+      "BillingZipcode": "02915",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_V_2A.json
+++ b/cert_fixtures/L_V_2A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "void",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_V_2.litleOnlineResponse.saleResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_V_3.json
+++ b/cert_fixtures/L_V_3.json
@@ -1,0 +1,18 @@
+{
+  "endpoint": "return",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4457010000000009",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16",
+      "CVV": "349"
+    }
+  }
+}

--- a/cert_fixtures/L_V_3A.json
+++ b/cert_fixtures/L_V_3A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "void",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_V_3.litleOnlineResponse.creditResponse.TransactionID}"
+    }
+  }
+}

--- a/cert_fixtures/L_V_4.json
+++ b/cert_fixtures/L_V_4.json
@@ -1,0 +1,26 @@
+{
+  "endpoint": "sale",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "101.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345"
+    },
+    "Card": {
+      "Type": "VI",
+      "CardNumber": "4457010100000008",
+      "ExpirationMonth": "06",
+      "ExpirationYear": "16",
+      "CVV": "992"
+    },
+    "Address": {
+      "BillingName": "Joe Green",
+      "BillingAddress1": "6 Main St.",
+      "BillingCity": "Derry",
+      "BillingState": "NH",
+      "BillingZipcode": "03038",
+      "BillingCountry": "US"
+    }
+  }
+}

--- a/cert_fixtures/L_V_4A.json
+++ b/cert_fixtures/L_V_4A.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "void",
+  "body": {
+    "Transaction": {
+      "TransactionID": "#{L_V_4.litleOnlineResponse.saleResponse.TransactionID}"
+    }
+  }
+}

--- a/lib/vantiv-ruby.rb
+++ b/lib/vantiv-ruby.rb
@@ -1,2 +1,70 @@
+require 'json'
+require 'net/http'
+require 'vantiv/api'
+
 module Vantiv
+  def self.auth(body)
+    Api::Request.new(
+      endpoint: Api::Endpoints::AUTHORIZATION,
+      body: body
+    ).run
+  end
+
+  def self.auth_reversal(body)
+    Api::Request.new(
+      endpoint: Api::Endpoints::AUTH_REVERSAL,
+      body: body
+    ).run
+  end
+
+  def self.capture(body)
+    Api::Request.new(
+      endpoint: Api::Endpoints::CAPTURE,
+      body: body
+    ).run
+  end
+
+  # NOTE: ActiveMerchant's #auth_capture... what naming should we use here?
+  def self.sale(body)
+    Api::Request.new(
+      endpoint: Api::Endpoints::SALE,
+      body: body
+    ).run
+  end
+
+  # NOTE: ActiveMerchant's #refund... only for use on a capture or sale it seems
+  #       -> 'returns' are refunds too, credits are tied to a sale/capture, returns can be willy nilly
+  def self.credit(body)
+    Api::Request.new(
+      endpoint: Api::Endpoints::CREDIT,
+      body: body
+    ).run
+  end
+
+  def self.return(body)
+    Api::Request.new(
+      endpoint: Api::Endpoints::RETURN,
+      body: body
+    ).run
+  end
+
+  # NOTE: can void credits
+  def self.void(body)
+    Api::Request.new(
+      endpoint: Api::Endpoints::VOID,
+      body: body
+    ).run
+  end
+
+  def self.configure
+    yield self
+  end
+
+  class << self
+    attr_accessor :license_id, :acceptor_id, :application_id, :default_report_group
+  end
+
+  def self.root
+    File.dirname __dir__
+  end
 end

--- a/lib/vantiv/api.rb
+++ b/lib/vantiv/api.rb
@@ -1,0 +1,7 @@
+require 'vantiv/api/response'
+require 'vantiv/api/authorization_response'
+
+require 'vantiv/api/request'
+
+# Require endpoints last, as it maps endpoints with response classes
+require 'vantiv/api/endpoints'

--- a/lib/vantiv/api/authorization_response.rb
+++ b/lib/vantiv/api/authorization_response.rb
@@ -1,0 +1,24 @@
+module Vantiv
+  module Api
+    class AuthorizationResponse < Api::Response
+      def success?
+        !failure?
+      end
+
+      def failure?
+        api_level_failure? || authorization_successful?
+      end
+
+      private
+
+      def authorization_successful?
+        # TODO: review API docs and update this
+        litle_response_code == '000'
+      end
+
+      def authorization_unsuccessful?
+        !authorization_successful?
+      end
+    end
+  end
+end

--- a/lib/vantiv/api/endpoints.rb
+++ b/lib/vantiv/api/endpoints.rb
@@ -1,0 +1,37 @@
+module Vantiv
+  module Api
+    module Endpoints
+      class Base < Struct.new(:url, :response_class)
+      end
+      AUTHORIZATION = Base.new(
+        "payment/sp2/credit/v1/authorization",
+        Vantiv::Api::AuthorizationResponse
+      )
+      CAPTURE = Base.new(
+        "payment/sp2/credit/v1/authorizationCompletion",
+        Vantiv::Api::Response
+      )
+      AUTH_REVERSAL = Base.new(
+        "payment/sp2/credit/v1/reversal",
+        Vantiv::Api::Response
+      )
+      SALE = Base.new(
+        "payment/sp2/credit/v1/sale",
+        Vantiv::Api::Response
+      )
+      CREDIT = Base.new(
+        "payment/sp2/credit/v1/credit",
+        Vantiv::Api::Response
+      )
+      RETURN = Base.new(
+        "payment/sp2/credit/v1/return",
+        Vantiv::Api::Response
+      )
+      VOID = Base.new(
+        "payment/sp2/credit/v1/void",
+        Vantiv::Api::Response
+      )
+    end
+  end
+end
+

--- a/lib/vantiv/api/request.rb
+++ b/lib/vantiv/api/request.rb
@@ -1,0 +1,55 @@
+module Vantiv
+  class Api::Request
+
+    attr_reader :body
+
+    def initialize(endpoint:, body:)
+      @endpoint = endpoint
+      @body = build_request_body(body)
+    end
+
+    def run
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+
+      request = Net::HTTP::Post.new(uri.request_uri, header)
+      request.body = body
+      endpoint.response_class.new(http.request(request))
+    end
+
+    private
+
+    attr_reader :endpoint
+
+    def header
+      {
+        "Content-Type" =>"application/json",
+        "Authorization" => "VANTIV license=\"#{Vantiv.license_id}\""
+      }
+    end
+
+    def build_request_body(body)
+      request_body_base.merge(body).to_json
+    end
+
+    def request_body_base
+      {
+        "Credentials" => {
+          "AcceptorID" => Vantiv.acceptor_id
+        },
+        "Reports" => {
+          # NOTE: this is required, so a default is left here.
+          #       If a user wants to use this Vantiv feature, it can be made dynamic.
+          "ReportGroup" => Vantiv.default_report_group
+        },
+        "Application" => {
+          "ApplicationID" => Vantiv.application_id
+        }
+      }
+    end
+
+    def uri
+      @uri ||= URI.parse("https://apis.cert.vantiv.com/#{endpoint.url}")
+    end
+  end
+end

--- a/lib/vantiv/api/response.rb
+++ b/lib/vantiv/api/response.rb
@@ -1,0 +1,27 @@
+module Vantiv
+  module Api
+    class Response
+      attr_reader :raw_response, :body
+
+      def initialize(raw_response)
+        @raw_response = raw_response
+        @body = JSON.parse(raw_response.body)
+      end
+
+      # Only returned by cert API?
+      def request_id
+        body["RequestID"]
+      end
+
+      private
+
+      def api_level_failure?
+        raw_response.code_type != Net::HTTPOK &&
+          # NOTE: this kind of sucks, but at the commit point, the DevHub
+          #   Api sometimes gives 200OK when litle had a parse issue and returns
+          #   'Error validating xml data...' instead of an actual error
+          @body["litleOnlineResponse"]["@message"].match("[E|e]rror")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end

--- a/vantiv-ruby.gemspec
+++ b/vantiv-ruby.gemspec
@@ -10,6 +10,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://wwww.plated.com/edit-this-url'
   s.license     = 'edit this too'
 
+  s.executables << 'vantiv-certify-app'
+
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'pry'
 end

--- a/vantiv-ruby.gemspec
+++ b/vantiv-ruby.gemspec
@@ -6,7 +6,10 @@ Gem::Specification.new do |s|
   s.description = "A simple hello world gem"
   s.authors     = ["Josh Balloch"]
   s.email       = 'joshuaballoch@gmail.com'
-  s.files       = ["lib/vantiv-ruby.rb"]
+  s.files       = `git ls-files`.split("\n")
   s.homepage    = 'https://wwww.plated.com/edit-this-url'
   s.license     = 'edit this too'
+
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'pry'
 end


### PR DESCRIPTION
As a user of this gem,
I want to be able to send cert API requests,
So that I can certify my app(s) with Vantiv.

Basically, I've run through most of the Vantiv DevHub API in Paw, by going through their certification tests. These tests require the user to run requests on all the features an app would use (authorization, capture, etc..) with different payloads (e.g. running auths on valid accounts, invalid cards, accounts with no funds, etc..) to verify that the user is running correct requests.

In this P.R. I want to introduce a structure to automate running these requests. This will also get me an initial (if incomplete and suboptimal) API for the gem to run:

1. Auths
2. Captures (of auths)
4. Auth Reversals
3. Auth_captures (vantiv calls these Sales)
5. Voids
6. Refunds (vantiv calls these "Returns and Credit")

I think that will be a good starting point to then start to change the API of the gem in the context of using it in an application.

