### PR TITLE
Add auth_capture capability

### DIFF
--- a/lib/vantiv-ruby.rb
+++ b/lib/vantiv-ruby.rb
@@ -31,11 +31,17 @@ module Vantiv
     ).run
   end
 
-  # NOTE: ActiveMerchant's #auth_capture... what naming should we use here?
-  def self.sale(body)
+  def self.auth_capture(amount:, payment_account_id:, customer_id:, order_id:)
+    body = Api::SaleRequestBody.generate(
+      amount: amount,
+      customer_id: customer_id,
+      payment_account_id: payment_account_id,
+      order_id: order_id
+    )
     Api::Request.new(
       endpoint: Api::Endpoints::SALE,
-      body: body
+      body: body,
+      response_class: Api::SaleResponse
     ).run
   end
 

--- a/lib/vantiv/api.rb
+++ b/lib/vantiv/api.rb
@@ -1,8 +1,10 @@
 require 'vantiv/api/response'
 require 'vantiv/api/authorization_response'
+require 'vantiv/api/sale_response'
 
 require 'vantiv/api/request'
 require 'vantiv/api/auth_request_body'
+require 'vantiv/api/sale_request_body'
 
 # Require endpoints last, as it maps endpoints with response classes
 require 'vantiv/api/endpoints'

--- a/lib/vantiv/api/authorization_response.rb
+++ b/lib/vantiv/api/authorization_response.rb
@@ -9,46 +9,31 @@ module Vantiv
       }
 
       def success?
-        !failure?
+        !api_level_failure? && transaction_approved?
       end
 
       def failure?
-        api_level_failure? || authorization_unsuccessful?
-      end
-
-      def auth_response_code
-        auth_response["response"]
-      end
-
-      def transaction_id
-        auth_response["TransactionID"]
-      end
-
-      def message
-        auth_response["message"]
+        !success?
       end
 
       def insufficient_funds?
-        auth_response_code == ResponseCodes[:insufficient_funds]
+        response_code == ResponseCodes[:insufficient_funds]
       end
 
       def invalid_account_number?
-        auth_response_code == ResponseCodes[:invalid_account_number]
+        response_code == ResponseCodes[:invalid_account_number]
       end
 
       private
 
-      def auth_response
-        body["litleOnlineResponse"]["authorizationResponse"]
+      def transaction_approved?
+        response_code == ResponseCodes[:approved]
       end
 
-      def authorization_successful?
-        auth_response_code == ResponseCodes[:approved]
+      def transaction_response_name
+        "authorizationResponse"
       end
 
-      def authorization_unsuccessful?
-        !authorization_successful?
-      end
     end
   end
 end

--- a/lib/vantiv/api/response.rb
+++ b/lib/vantiv/api/response.rb
@@ -20,6 +20,32 @@ module Vantiv
           #   'Error validating xml data...' instead of an actual error
           @body["litleOnlineResponse"]["@message"].match(/error/i)
       end
+
+      def message
+        litle_transaction_response["message"]
+      end
+
+      def response_code
+        litle_transaction_response["response"]
+      end
+
+      def transaction_id
+        litle_transaction_response["TransactionID"]
+      end
+
+      private
+
+      def litle_response
+        body["litleOnlineResponse"]
+      end
+
+      def litle_transaction_response
+        litle_response[transaction_response_name]
+      end
+
+      def transaction_response_name
+        raise "not implemented!"
+      end
     end
   end
 end

--- a/lib/vantiv/api/sale_request_body.rb
+++ b/lib/vantiv/api/sale_request_body.rb
@@ -1,0 +1,38 @@
+module Vantiv
+  module Api
+    class SaleRequestBody
+      def self.generate(amount:, payment_account_id:, customer_id:, order_id:)
+        new(
+          amount: amount,
+          payment_account_id: payment_account_id,
+          customer_id: customer_id,
+          order_id: order_id
+        ).to_hash
+      end
+
+      attr_reader :amount, :payment_account_id, :customer_id, :order_id
+
+      def initialize(amount:, payment_account_id:, customer_id:, order_id:)
+        @amount = amount
+        @payment_account_id = payment_account_id
+        @customer_id = customer_id
+        @order_id = order_id
+      end
+
+      def to_hash
+        {
+          "Transaction" => {
+            "ReferenceNumber" => order_id,
+            "TransactionAmount" => '%.2f' % (amount / 100.0),
+            "OrderSource" => Vantiv.order_source,
+            "CustomerID" => customer_id,
+            "PartialApprovedFlag" => false
+          },
+          "PaymentAccount" => {
+            "PaymentAccountID" => payment_account_id
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/vantiv/api/sale_response.rb
+++ b/lib/vantiv/api/sale_response.rb
@@ -1,0 +1,38 @@
+module Vantiv
+  module Api
+    class SaleResponse < Api::Response
+      ResponseCodes = {
+        approved: '000',
+        insufficient_funds: '110',
+        invalid_account_number: '301',
+        token_not_found: '822'
+      }
+
+      def success?
+        !api_level_failure? && transaction_approved?
+      end
+
+      def failure?
+        !success?
+      end
+
+      def insufficient_funds?
+        response_code == ResponseCodes[:insufficient_funds]
+      end
+
+      def invalid_account_number?
+        response_code == ResponseCodes[:invalid_account_number]
+      end
+
+      private
+
+      def transaction_approved?
+        response_code == ResponseCodes[:approved]
+      end
+
+      def transaction_response_name
+        "saleResponse"
+      end
+    end
+  end
+end

--- a/spec/api/auth_request_body_spec.rb
+++ b/spec/api/auth_request_body_spec.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'spec_helper'
 
 describe Vantiv::Api::AuthRequestBody do

--- a/spec/api/sale_request_body_spec.rb
+++ b/spec/api/sale_request_body_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Vantiv::Api::SaleRequestBody do
+  subject(:request_body) do
+    Vantiv::Api::SaleRequestBody.generate(
+      amount: 422984,
+      customer_id: "extid123",
+      payment_account_id: "paymentacct123",
+      order_id: "SomeOrder123"
+    )
+  end
+
+  it "formats the amount (in cents) as dollar 2 decimal format" do
+    expect(request_body["Transaction"]["TransactionAmount"]).to eq "4229.84"
+  end
+
+  it "includes a customer ID (required by Vantiv)" do
+    expect(request_body["Transaction"]["CustomerID"]).to eq "extid123"
+  end
+
+  it "includes the default order source" do
+    expect(request_body["Transaction"]["OrderSource"]).to eq "ecommerce"
+  end
+
+  it "includes the merchant reference number for the order (required by Vantiv)" do
+    expect(request_body["Transaction"]["ReferenceNumber"]).to eq "SomeOrder123"
+  end
+
+  it "includes the PaymentAccountID" do
+    expect(request_body["PaymentAccount"]["PaymentAccountID"]).to eq "paymentacct123"
+  end
+end

--- a/spec/auth_capture_spec.rb
+++ b/spec/auth_capture_spec.rb
@@ -1,0 +1,122 @@
+require 'spec_helper'
+
+describe "auth_capture (Sale)" do
+  let(:customer_external_id) { "1234" }
+
+  subject(:run_auth_capture) do
+    Vantiv.auth_capture(
+      amount: 10000,
+      payment_account_id: payment_account_id,
+      customer_id: customer_external_id,
+      order_id: "SomeOrder123"
+    )
+  end
+
+  context "on a valid account" do
+    let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+
+    it "returns success response" do
+      response = run_auth_capture
+      expect(response.success?).to eq true
+    end
+
+    it "returns a transaction ID" do
+      response = run_auth_capture
+      expect(response.transaction_id).not_to eq nil
+      expect(response.transaction_id).not_to eq ""
+    end
+  end
+
+  context "on an account with insufficient funds" do
+    let(:payment_account_id) { Vantiv::TestAccount.insufficient_funds.payment_account_id }
+
+    it "returns a failure response" do
+      response = run_auth_capture
+      expect(response.success?).to eq false
+      expect(response.failure?).to eq true
+    end
+
+    it "returns a transaction ID" do
+      response = run_auth_capture
+      expect(response.transaction_id).not_to eq nil
+      expect(response.transaction_id).not_to eq ""
+    end
+
+    it "gives a human readable reason" do
+      response = run_auth_capture
+      expect(response.message).to match(/insufficient funds/i)
+    end
+
+    it "notifies that it is insufficient funds (110?)" do
+      response = run_auth_capture
+      expect(response.insufficient_funds?).to eq true
+    end
+  end
+
+  context "on an account with an invalid account number" do
+    let(:payment_account_id) { Vantiv::TestAccount.invalid_account_number.payment_account_id }
+
+    it "returns a failure response" do
+      response = run_auth_capture
+      expect(response.success?).to eq false
+      expect(response.failure?).to eq true
+    end
+
+    it "returns a transaction ID" do
+      response = run_auth_capture
+      expect(response.transaction_id).not_to eq nil
+      expect(response.transaction_id).not_to eq ""
+    end
+
+    it "gives a human readable reason" do
+      response = run_auth_capture
+      expect(response.message).to match(/invalid account number/i)
+    end
+
+    it "responds to invalid_account_number?" do
+      response = run_auth_capture
+      expect(response.invalid_account_number?).to eq true
+    end
+  end
+
+  context "on an account with misc errors, like pick up card" do
+    let(:payment_account_id) { Vantiv::TestAccount.pick_up_card.payment_account_id }
+
+    it "returns a failure response" do
+      response = run_auth_capture
+      expect(response.success?).to eq false
+      expect(response.failure?).to eq true
+    end
+
+    it "returns a transaction ID" do
+      response = run_auth_capture
+      expect(response.transaction_id).not_to eq nil
+      expect(response.transaction_id).not_to eq ""
+    end
+
+    it "gives a human readable reason" do
+      response = run_auth_capture
+      expect(response.message).not_to eq nil
+      expect(response.message).not_to eq ""
+    end
+  end
+
+  context "when API level failure occurs" do
+    let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+
+    before do
+      @license_id = Vantiv.license_id
+      Vantiv.license_id = "invalid"
+    end
+
+    after do
+      Vantiv.license_id = @license_id
+    end
+
+    it "responds that the authorization failed" do
+      response = run_auth_capture
+      expect(response.failure?).to eq true
+      expect(response.api_level_failure?).to eq true
+    end
+  end
+end


### PR DESCRIPTION
Leaving the `auth_capture` wording to keep parity with current language (from ActiveMerchant), but using vocab consistent with Vantiv's API underneath, where it's called a sale.