### PR TITLE
Test e-protect (Add tokenization to upgrade temp tokens to payment account IDs:)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,35 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
+    capybara (2.6.2)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    childprocess (0.5.9)
+      ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.1)
     diff-lcs (1.2.5)
     dotenv (2.1.0)
+    ffi (1.9.10)
     method_source (0.8.2)
+    mime-types (3.0)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0221)
+    mini_portile2 (2.0.0)
+    multi_json (1.11.2)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rack (1.6.4)
+    rack-test (0.6.3)
+      rack (>= 1.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -27,15 +48,26 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rubyzip (1.2.0)
+    selenium-webdriver (2.52.0)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     slop (3.6.0)
+    websocket (1.2.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   dotenv
   pry
   rspec
+  selenium-webdriver
   vantiv-ruby!
 
 BUNDLED WITH

--- a/lib/vantiv-ruby.rb
+++ b/lib/vantiv-ruby.rb
@@ -4,6 +4,10 @@ require 'vantiv/api'
 
 module Vantiv
   def self.tokenize(temporary_token:)
+    if temporary_token == "" or temporary_token == nil
+      raise ArgumentError.new("Blank temporary token (PaypageRegistrationID): \n
+                               Check that paypage error handling is implemented correctly.")
+    end
     body = Api::TokenizationRequestBody.generate(
       paypage_registration_id: temporary_token
     )

--- a/lib/vantiv-ruby.rb
+++ b/lib/vantiv-ruby.rb
@@ -3,6 +3,17 @@ require 'net/http'
 require 'vantiv/api'
 
 module Vantiv
+  def self.tokenize(temporary_token:)
+    body = Api::TokenizationRequestBody.generate(
+      paypage_registration_id: temporary_token
+    )
+    Api::Request.new(
+      endpoint: Api::Endpoints::TOKENIZATION,
+      body: body,
+      response_class: Api::TokenizationResponse
+    ).run
+  end
+
   def self.auth(amount:, payment_account_id:, customer_id:, order_id:)
     body = Api::AuthRequestBody.generate(
       amount: amount,

--- a/lib/vantiv/api.rb
+++ b/lib/vantiv/api.rb
@@ -1,10 +1,12 @@
 require 'vantiv/api/response'
 require 'vantiv/api/authorization_response'
 require 'vantiv/api/sale_response'
+require 'vantiv/api/tokenization_response'
 
 require 'vantiv/api/request'
 require 'vantiv/api/auth_request_body'
 require 'vantiv/api/sale_request_body'
+require 'vantiv/api/tokenization_request_body'
 
 # Require endpoints last, as it maps endpoints with response classes
 require 'vantiv/api/endpoints'

--- a/lib/vantiv/api/endpoints.rb
+++ b/lib/vantiv/api/endpoints.rb
@@ -7,6 +7,7 @@ module Vantiv
       SALE = "payment/sp2/credit/v1/sale"
       CREDIT = "payment/sp2/credit/v1/credit"
       RETURN = "payment/sp2/credit/v1/return"
+      TOKENIZATION = "payment/sp2/services/v1/paymentAccountCreate"
       VOID = "payment/sp2/credit/v1/void"
     end
   end

--- a/lib/vantiv/api/tokenization_request_body.rb
+++ b/lib/vantiv/api/tokenization_request_body.rb
@@ -1,0 +1,23 @@
+module Vantiv
+  module Api
+    class TokenizationRequestBody
+      def self.generate(paypage_registration_id:)
+        new(paypage_registration_id: paypage_registration_id).to_hash
+      end
+
+      attr_reader :paypage_registration_id
+
+      def initialize(paypage_registration_id:)
+        @paypage_registration_id = paypage_registration_id
+      end
+
+      def to_hash
+        {
+          "Card" => {
+            "PaypageRegistrationID" => paypage_registration_id
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/vantiv/api/tokenization_response.rb
+++ b/lib/vantiv/api/tokenization_response.rb
@@ -1,0 +1,42 @@
+require 'pry'
+module Vantiv
+  module Api
+    class TokenizationResponse < Api::Response
+      ResponseCodes = {
+        account_successfully_registered: "801",
+        account_already_registered: "802",
+        credit_card_number_invalid: "820",
+        merchant_not_authorized_for_tokens: "821",
+        token_not_found: "822",
+        token_invalid: "823",
+        invalid_paypage_registration_id: "877",
+        expired_paypage_registration_id: "878",
+        generic_token_registration_error: "898",
+        generic_token_use_error: "899"
+      }
+
+      def success?
+        !api_level_failure? && tokenization_successful?
+      end
+
+      def failure?
+        !success?
+      end
+
+      def payment_account_id
+        success? ? litle_transaction_response["PaymentAccountID"] : nil
+      end
+
+      private
+
+      def tokenization_successful?
+        response_code == ResponseCodes[:account_successfully_registered] ||
+          response_code == ResponseCodes[:account_already_registered]
+      end
+
+      def transaction_response_name
+        "registerTokenResponse"
+      end
+    end
+  end
+end

--- a/spec/e_protect_spec.rb
+++ b/spec/e_protect_spec.rb
@@ -40,6 +40,15 @@ describe "promoting a temporary token to a permanent token", type: :feature do
     end
   end
 
+  context "with a blank temporary token" do
+
+    it "raises an error" do
+      expect{
+        Vantiv.tokenize(temporary_token: "")
+      }.to raise_error ArgumentError, /blank temporary token/i
+    end
+  end
+
   context "with an invalid account number
            (where number is technically valid, and the actual account is invalid)" do
 

--- a/spec/e_protect_spec.rb
+++ b/spec/e_protect_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+describe "promoting a temporary token to a permanent token", type: :feature do
+  let(:response) do
+    Vantiv.tokenize(temporary_token: paypage_registration_id)
+  end
+
+  context "with a valid temporary token" do
+    before :all do
+      @card_to_tokenize = Vantiv::TestAccount.valid_account
+      @paypage_registration_id = get_paypage_registration_id
+    end
+
+    let(:paypage_registration_id) { @paypage_registration_id }
+
+    it "returns success" do
+      expect(response.success?).to eq true
+    end
+
+    it "returns the permanent token (payment account id)" do
+      expect(response.payment_account_id).not_to eq nil
+      expect(response.payment_account_id).not_to eq ""
+    end
+
+    it "enables using the permanent token on other transactions" do
+      payment_account_id = response.payment_account_id
+
+      auth_response = Vantiv.auth(
+        amount: 10000,
+        payment_account_id: payment_account_id,
+        customer_id: "doesntmatter",
+        order_id: "orderblah"
+      )
+      expect(auth_response.success?).to eq true
+    end
+
+    it "returns a transaction id" do
+      expect(response.transaction_id).not_to eq nil
+      expect(response.transaction_id).not_to eq ""
+    end
+  end
+
+  context "with an invalid account number
+           (where number is technically valid, and the actual account is invalid)" do
+
+    before :all do
+      @card_to_tokenize = Vantiv::TestAccount.invalid_account_number
+      @paypage_registration_id = get_paypage_registration_id
+    end
+
+    let(:paypage_registration_id) { @paypage_registration_id }
+
+    it "returns success" do
+      expect(response.success?).to eq true
+      expect(response.failure?).to eq false
+    end
+
+    it "returns a permanent token" do
+      expect(response.payment_account_id).not_to eq nil
+      expect(response.payment_account_id).not_to eq ""
+    end
+
+    it "returns a transaction id" do
+      expect(response.transaction_id).not_to eq nil
+      expect(response.transaction_id).not_to eq ""
+    end
+
+    it "notifies that the account is invalid on a subsequent transaction" do
+      payment_account_id = response.payment_account_id
+
+      auth_response = Vantiv.auth(
+        amount: 10000,
+        payment_account_id: payment_account_id,
+        customer_id: "doesntmatter",
+        order_id: "orderblah"
+      )
+      expect(auth_response.success?).to eq false
+      expect(auth_response.invalid_account_number?).to eq true
+    end
+  end
+
+  context "with an invalid temporary token" do
+    let(:paypage_registration_id) do
+      "d8Vp9k5Ja7JidnptLythMnhDb3FjQ3IzZlA1RG1CLzhrd2cwbHladUhuNTBucy94c1R2NDdWN2JoUFNLTng1cQ=="
+    end
+
+    it "returns failure" do
+      expect(response.success?).to eq false
+      expect(response.failure?).to eq true
+    end
+
+    it "does not return a permanent token" do
+      expect(response.payment_account_id).to eq nil
+    end
+
+    it "returns a corresponding response code" do
+      expect(response.response_code).to eq(
+        Vantiv::Api::TokenizationResponse::ResponseCodes[:invalid_paypage_registration_id]
+      )
+    end
+
+    it "returns a transaction id" do
+      expect(response.transaction_id).not_to eq nil
+      expect(response.transaction_id).not_to eq ""
+    end
+  end
+
+  def get_paypage_registration_id
+    visit("https://apideveloper.vantiv.com/docs/eprotect-check-out-page-cvv")
+    expect(page).to have_content("eProtect IFrame with CVV")
+
+    fill_in("ccNum", with: @card_to_tokenize.card_number)
+    fill_in("cvv2Num", with: @card_to_tokenize.cvv)
+
+    click_button "Check out"
+
+    tempTokenInput = find("#paypageRegistrationId")
+    expect(tempTokenInput).to have_content
+
+    temp_token = tempTokenInput.value
+    expect(temp_token).not_to eq ""
+    temp_token
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,21 +1,24 @@
+require 'vantiv-ruby'
+require 'capybara/rspec'
+require 'dotenv'
+Dotenv.load
+Dir["#{Vantiv.root}/spec/support/**/*.rb"].each {|f| require f}
 
+Vantiv.configure do |config|
+  config.license_id = ENV["LICENSE_ID"]
+  config.acceptor_id = ENV["ACCEPTOR_ID"]
+  config.application_id = ENV["APP_ID"]
+  config.order_source = "ecommerce"
+
+  config.default_report_group = '1'
+end
+
+Capybara.configure do |config|
+  config.run_server = false
+  config.default_driver = :selenium
+end
 
 RSpec.configure do |config|
-  require 'vantiv-ruby'
-  require 'dotenv'
-  Dotenv.load
-
-  Dir["#{Vantiv.root}/spec/support/**/*.rb"].each {|f| require f}
-
-  Vantiv.configure do |config|
-    config.license_id = ENV["LICENSE_ID"]
-    config.acceptor_id = ENV["ACCEPTOR_ID"]
-    config.application_id = ENV["APP_ID"]
-    config.order_source = "ecommerce"
-
-    config.default_report_group = '1'
-  end
-
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/support/test_account.rb
+++ b/spec/support/test_account.rb
@@ -15,7 +15,8 @@ module Vantiv
       fetch_account(
         card_number: "4457010000000009",
         expiry_month: "01",
-        expiry_year: "16"
+        expiry_year: "16",
+        cvv: "349"
       )
     end
 
@@ -23,7 +24,8 @@ module Vantiv
       fetch_account(
         card_number: "4457010100000008",
         expiry_month: "06",
-        expiry_year: "16"
+        expiry_year: "16",
+        cvv: "992"
       )
     end
 
@@ -31,7 +33,8 @@ module Vantiv
       fetch_account(
         card_number: "5112010100000002",
         expiry_month: "07",
-        expiry_year: "16"
+        expiry_year: "16",
+        cvv: "251"
       )
     end
 
@@ -39,22 +42,24 @@ module Vantiv
       fetch_account(
         card_number: "375001010000003",
         expiry_month: "09",
-        expiry_year: "16"
+        expiry_year: "16",
+        cvv: "0421"
       )
     end
 
-    def self.fetch_account(card_number:, expiry_month:, expiry_year:)
-      acct = new(card_number, expiry_month, expiry_year)
+    def self.fetch_account(card_number:, expiry_month:, expiry_year:, cvv:)
+      acct = new(card_number, expiry_month, expiry_year, cvv)
       acct.read_or_get_data
       acct
     end
 
-    attr_reader :card_number, :expiry_month, :expiry_year, :payment_account_id
+    attr_reader :card_number, :expiry_month, :expiry_year, :payment_account_id, :cvv
 
-    def initialize(card_number, expiry_month, expiry_year)
+    def initialize(card_number, expiry_month, expiry_year, cvv)
       @card_number = card_number
       @expiry_month = expiry_month
       @expiry_year = expiry_year
+      @cvv = cvv
     end
 
     def read_or_get_data

--- a/vantiv-ruby.gemspec
+++ b/vantiv-ruby.gemspec
@@ -12,7 +12,9 @@ Gem::Specification.new do |s|
 
   s.executables << 'vantiv-certify-app'
 
-  s.add_development_dependency 'rspec'
   s.add_development_dependency 'dotenv'
+  s.add_development_dependency 'capybara'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'selenium-webdriver'
 end


### PR DESCRIPTION
* Takes a temporary_token (paypage_registration_id)
* Fetches a permanent token (PaymentAccountID)
* Includes tests