### PR TITLE
Improve gem operation when it's poorly configured

### DIFF
--- a/exe/vantiv-certify-app
+++ b/exe/vantiv-certify-app
@@ -1,9 +1,8 @@
 #!/usr/bin/env ruby
 require 'vantiv-ruby'
-require 'pry'
 
 unless ENV['ACCEPTOR_ID'] && ENV['APP_ID'] && ENV['LICENSE_ID']
-  raise "License ID, Acceptor ID and Application ID required"
+  raise "Vantiv License ID, Acceptor ID and Application ID required"
 end
 
 Vantiv.configure do |config|

--- a/lib/vantiv/api/auth_request_body.rb
+++ b/lib/vantiv/api/auth_request_body.rb
@@ -24,7 +24,7 @@ module Vantiv
           "Transaction" => {
             "ReferenceNumber" => order_id,
             "TransactionAmount" => '%.2f' % (amount / 100.0),
-            "OrderSource" => Vantiv.order_source,
+            "OrderSource" => get_order_source,
             "CustomerID" => customer_id,
             "PartialApprovedFlag" => false
           },
@@ -32,6 +32,11 @@ module Vantiv
             "PaymentAccountID" => payment_account_id
           }
         }
+      end
+
+      def get_order_source
+        raise "Missing Vantiv Config: order_source" unless Vantiv.order_source
+        Vantiv.order_source
       end
     end
   end

--- a/lib/vantiv/api/request.rb
+++ b/lib/vantiv/api/request.rb
@@ -10,6 +10,7 @@ module Vantiv
     end
 
     def run
+      validate_env_variables_exist
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
 
@@ -39,7 +40,7 @@ module Vantiv
           "AcceptorID" => Vantiv.acceptor_id
         },
         "Reports" => {
-          # NOTE: this is required, so a default is left here.
+          # NOTE: this is required by vantiv, so a default is left here.
           #       If a user wants to use this Vantiv feature, it can be made dynamic.
           "ReportGroup" => Vantiv.default_report_group
         },
@@ -51,6 +52,17 @@ module Vantiv
 
     def uri
       @uri ||= URI.parse("https://apis.cert.vantiv.com/#{endpoint}")
+    end
+
+    def validate_env_variables_exist
+      required_vars = %w(acceptor_id application_id license_id default_report_group)
+
+      missing_vars = required_vars.select do |v|
+        value = Vantiv.send(:"#{v}")
+        value == nil || value == ""
+      end
+
+      raise "Missing required Vantiv Configs: #{missing_vars.join(', ')}" if missing_vars.any?
     end
   end
 end

--- a/lib/vantiv/api/response.rb
+++ b/lib/vantiv/api/response.rb
@@ -36,11 +36,11 @@ module Vantiv
       private
 
       def litle_response
-        body["litleOnlineResponse"]
+        api_level_failure? ? {} : body["litleOnlineResponse"]
       end
 
       def litle_transaction_response
-        litle_response[transaction_response_name]
+        api_level_failure? ? {} : litle_response[transaction_response_name]
       end
 
       def transaction_response_name

--- a/spec/api/api_request_spec.rb
+++ b/spec/api/api_request_spec.rb
@@ -1,66 +1,102 @@
 require 'spec_helper'
 
 describe Vantiv::Api::Request do
+  let(:general_response_class) do
+    Class.new(Vantiv::Api::Response) do
+      def transaction_response_name
+        "tokenizationResponse"
+      end
+    end
+  end
+
   subject(:run_api_request) do
     Vantiv::Api::Request.new(
       endpoint: Vantiv::Api::Endpoints::TOKENIZATION,
       body: Vantiv::Api::TokenizationRequestBody.generate(
         paypage_registration_id: "1234"
       ),
-      response_class: Vantiv::Api::Response
+      response_class: general_response_class
     ).run
   end
 
-  let(:missing_vars) { {} }
-
-  before :each do
-    @cached_config = {}
-    missing_vars.each do |config_var|
-      @cached_config[config_var] = Vantiv.send(:"#{config_var}")
+  context "running an API request when authentication fails" do
+    before do
+      @cached_license_id = Vantiv.license_id
       Vantiv.configure do |config|
-        config.send(:"#{config_var}=", nil)
+        config.license_id = "asdfasdf"
+      end
+    end
+
+    after do
+      Vantiv.configure do |config|
+        config.license_id = @cached_license_id
+      end
+    end
+
+    it "does not raise errors on standard method retrieval" do
+      response = run_api_request
+      expect(response.message).to eq nil
+      expect(response.response_code).to eq nil
+      expect(response.transaction_id).to eq nil
+    end
+
+    it "returns an api level failure" do
+      expect(run_api_request.api_level_failure?).to eq true
+    end
+
+  end
+
+  context "running API requests when configs are missing" do
+    let(:missing_vars) { {} }
+
+    before :each do
+      @cached_config = {}
+      missing_vars.each do |config_var|
+        @cached_config[config_var] = Vantiv.send(:"#{config_var}")
+        Vantiv.configure do |config|
+          config.send(:"#{config_var}=", nil)
+        end
+      end
+    end
+
+    after :each do
+      missing_vars.each do |config_var|
+        Vantiv.configure do |config|
+          config.send(:"#{config_var}=", @cached_config[config_var])
+        end
+      end
+    end
+
+    context "if License ID not configured" do
+      let(:missing_vars) { ['license_id'] }
+
+      it "raises an error" do
+        expect{run_api_request}.to raise_error(/missing.*LICENSE_ID/i)
+      end
+    end
+
+    context "if application id not configured correctly" do
+      let(:missing_vars) { ['application_id'] }
+
+      it "raises an error" do
+        expect{run_api_request}.to raise_error(/missing.*application_id/i)
+      end
+    end
+
+    context "if Acceptor ID not configured" do
+      let(:missing_vars) { ['acceptor_id'] }
+
+      it "raises an error" do
+        expect{run_api_request}.to raise_error(/missing.*acceptor_id/i)
+      end
+    end
+
+    context "if default report group not configured" do
+      let(:missing_vars) { ['default_report_group'] }
+
+      it "raises an error" do
+        expect{run_api_request}.to raise_error(/missing.*default_report_group/i)
       end
     end
   end
-
-  after :each do
-    missing_vars.each do |config_var|
-      Vantiv.configure do |config|
-        config.send(:"#{config_var}=", @cached_config[config_var])
-      end
-    end
-  end
-
-  context "running an API request if License ID not configured" do
-    let(:missing_vars) { ['license_id'] }
-
-    it "raises an error" do
-      expect{run_api_request}.to raise_error(/missing.*LICENSE_ID/i)
-    end
-  end
-
-  context "running an API request application id not configured correctly" do
-    let(:missing_vars) { ['application_id'] }
-
-    it "raises an error" do
-      expect{run_api_request}.to raise_error(/missing.*application_id/i)
-    end
-  end
-
-  context "running an API request if Acceptor ID not configured" do
-    let(:missing_vars) { ['acceptor_id'] }
-
-    it "raises an error" do
-      expect{run_api_request}.to raise_error(/missing.*acceptor_id/i)
-    end
-  end
-
-  context "running an API request if default report group not configured" do
-    let(:missing_vars) { ['default_report_group'] }
-
-    it "raises an error" do
-      expect{run_api_request}.to raise_error(/missing.*default_report_group/i)
-    end
-  end
-
 end

--- a/spec/api/api_request_spec.rb
+++ b/spec/api/api_request_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Vantiv::Api::Request do
+  subject(:run_api_request) do
+    Vantiv::Api::Request.new(
+      endpoint: Vantiv::Api::Endpoints::TOKENIZATION,
+      body: Vantiv::Api::TokenizationRequestBody.generate(
+        paypage_registration_id: "1234"
+      ),
+      response_class: Vantiv::Api::Response
+    ).run
+  end
+
+  let(:missing_vars) { {} }
+
+  before :each do
+    @cached_config = {}
+    missing_vars.each do |config_var|
+      @cached_config[config_var] = Vantiv.send(:"#{config_var}")
+      Vantiv.configure do |config|
+        config.send(:"#{config_var}=", nil)
+      end
+    end
+  end
+
+  after :each do
+    missing_vars.each do |config_var|
+      Vantiv.configure do |config|
+        config.send(:"#{config_var}=", @cached_config[config_var])
+      end
+    end
+  end
+
+  context "running an API request if License ID not configured" do
+    let(:missing_vars) { ['license_id'] }
+
+    it "raises an error" do
+      expect{run_api_request}.to raise_error(/missing.*LICENSE_ID/i)
+    end
+  end
+
+  context "running an API request application id not configured correctly" do
+    let(:missing_vars) { ['application_id'] }
+
+    it "raises an error" do
+      expect{run_api_request}.to raise_error(/missing.*application_id/i)
+    end
+  end
+
+  context "running an API request if Acceptor ID not configured" do
+    let(:missing_vars) { ['acceptor_id'] }
+
+    it "raises an error" do
+      expect{run_api_request}.to raise_error(/missing.*acceptor_id/i)
+    end
+  end
+
+  context "running an API request if default report group not configured" do
+    let(:missing_vars) { ['default_report_group'] }
+
+    it "raises an error" do
+      expect{run_api_request}.to raise_error(/missing.*default_report_group/i)
+    end
+  end
+
+end

--- a/spec/api/auth_request_body_spec.rb
+++ b/spec/api/auth_request_body_spec.rb
@@ -29,4 +29,24 @@ describe Vantiv::Api::AuthRequestBody do
   it "includes the PaymentAccountID" do
     expect(request_body["PaymentAccount"]["PaymentAccountID"]).to eq "paymentacct123"
   end
+
+  context "if an order source has not been configured" do
+
+    before :each do
+      @cached_order_source = Vantiv.order_source
+      Vantiv.configure do |config|
+        config.order_source = nil
+      end
+    end
+
+    after :each do
+      Vantiv.configure do |config|
+        config.order_source = @cached_order_source
+      end
+    end
+
+    it "raises an error if an order source has not been configured" do
+      expect{request_body}.to raise_error(/missing.*order_source/i)
+    end
+  end
 end


### PR DESCRIPTION
1. Raise errors when the user has not configured required things in the gem.
2. Give more helpful responses back when an api level failure (like authentication failure) occurs