### PR TITLE
Add test paypage server to retrieve paypageRegistrationIds in test:

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 ACCEPTOR_ID="paste-vantiv-acceptor-id-here"
 APP_ID="paste-vantiv-application-id-here"
 LICENSE_ID="paste-vantiv-license-id-here"
+PAYPAGE_ID="paste-vantiv-paypage-id-here"

--- a/lib/vantiv-ruby.rb
+++ b/lib/vantiv-ruby.rb
@@ -90,7 +90,12 @@ module Vantiv
   end
 
   class << self
-    attr_accessor :license_id, :acceptor_id, :application_id, :default_report_group, :order_source
+    attr_accessor :license_id, :acceptor_id, :application_id, :default_report_group, :order_source, :paypage_id
+
+    def paypage_id
+      raise "Missing Vantiv configuration: paypage_id" unless @paypage_id
+      @paypage_id
+    end
   end
 
   def self.root

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe "Vantiv configuration" do
+
+  describe "- accessing paypage id" do
+
+    it "works" do
+      expect(Vantiv.paypage_id).not_to eq nil
+      expect(Vantiv.paypage_id).not_to eq ""
+    end
+
+    context "when it has not been configured" do
+      before do
+        @cached_paypage_id = Vantiv.paypage_id
+        Vantiv.configure do |config|
+          config.paypage_id = nil
+        end
+      end
+
+      after do
+        Vantiv.configure do |config|
+          config.paypage_id = @cached_paypage_id
+        end
+      end
+
+      it "raises an error" do
+        expect{ Vantiv.paypage_id }.to raise_error(/missing.*paypage_id/i)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ Vantiv.configure do |config|
 end
 
 Capybara.configure do |config|
+  config.default_max_wait_time = 20
   config.run_server = false
   config.default_driver = :selenium
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ Vantiv.configure do |config|
   config.acceptor_id = ENV["ACCEPTOR_ID"]
   config.application_id = ENV["APP_ID"]
   config.order_source = "ecommerce"
+  config.paypage_id = ENV["PAYPAGE_ID"]
 
   config.default_report_group = '1'
 end

--- a/spec/support/e-protect/index.html.erb
+++ b/spec/support/e-protect/index.html.erb
@@ -1,0 +1,76 @@
+<html>
+  <head>
+    <script src="https://code.jquery.com/jquery-2.2.1.min.js" type="text/javascript"></script>
+    <script src="https://request-prelive.np-securepaypage-litle.com/LitlePayPage/js/payframe-client.min.js" type="text/javascript"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function(){
+        var payframeClientCallback = function(response) {
+          if (response.response !== '870') {
+            document.getElementById('request-status').innerHTML = 'Request Failed';
+            document.getElementById('payment-errors').innerHTML = response.message;
+          } else {
+            document.getElementById('temp-token').innerHTML = response.paypageRegistrationId;
+            document.getElementById('request-status').innerHTML = 'Request Complete';
+          }
+        }
+
+        var client = new LitlePayframeClient({
+          "paypageId": "<%= Vantiv.paypage_id %>",
+          "style":"sample2",
+          "height":"250",
+          "reportGroup":"IFrame Sample",
+          "timeout":"60000",
+          "div": "payframe",
+          "callback": payframeClientCallback,
+          "showCvv": true,
+          "months": {
+            "1":"January",
+            "2":"February",
+            "3":"March",
+            "4":"April",
+            "5":"May",
+            "6":"June",
+            "7":"July",
+            "8":"August",
+            "9":"September",
+            "10":"October",
+            "11":"November",
+            "12":"December"
+          },
+          "numYears": 8,
+          "tooltipText": "A CVV is the 3 digit code on the back of your Visa, MasterCard and Discover or a 4 digit code on the front of your American Express",
+          "tabIndex": {
+            "cvv":4,
+            "accountNumber":1,
+            "expMonth":2,
+            "expYear":3
+          },
+          "placeholderText": {
+            "cvv":"CVV",
+            "accountNumber":"Account Number"
+          }
+        });
+
+        window.onFormSubmit = function(){
+          client.getPaypageRegistrationId({
+            "id": "12345",
+            "orderId": "somethingunintelligble"
+          });
+
+          return false;
+        }
+      });
+    </script>
+  </head>
+  <body>
+    <h1>Vantiv Test Paypage</h1>
+    <form id="payment-form" onsubmit="return onFormSubmit()">
+      <div id="payframe"></div>
+      <div id="payment-errors"></div>
+      <div id="request-status"></div>
+      <div id="temp-token"></div>
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>
+

--- a/spec/support/test_account.rb
+++ b/spec/support/test_account.rb
@@ -87,13 +87,13 @@ module Vantiv
 
     def tokenization_request_body
       {
-        "Transaction": {
-          "CustomerID": "123"
+        "Transaction" => {
+          "CustomerID" => "123"
         },
-        "Card": {
-          "AccountNumber": card_number,
-          "ExpirationMonth": expiry_month,
-          "ExpirationYear": expiry_year
+        "Card" => {
+          "AccountNumber" => card_number,
+          "ExpirationMonth" => expiry_month,
+          "ExpirationYear" => expiry_year
         }
       }
     end

--- a/spec/support/test_paypage_server.rb
+++ b/spec/support/test_paypage_server.rb
@@ -1,0 +1,68 @@
+require 'erb'
+require 'webrick'
+require 'vantiv-ruby'
+
+module Vantiv
+  class TestPaypageServer
+    def initialize(threaded: true)
+      @threaded = threaded
+      @template = "#{Vantiv.root}/spec/support/e-protect/index.html.erb"
+      @static_file_dir = "#{Vantiv.root}/tmp/e-protect"
+    end
+
+    def start
+      if threaded
+        @server_thread = Thread.new { start_server }
+      else
+        start_server
+      end
+    end
+
+    def root_path
+      "http://localhost:#{port}"
+    end
+
+    def stop
+      threaded ? Thread.kill(server_thread) : stop_server
+    end
+
+    private
+
+    attr_accessor :server, :server_thread, :threaded
+
+    def document_root
+      File.expand_path "#{static_file_dir}"
+    end
+
+    def port
+      8000
+    end
+
+    def start_server
+      compile_template
+      server = WEBrick::HTTPServer.new :Port => port, :DocumentRoot => document_root
+      trap('INT') { server.shutdown }
+      server.start
+    end
+
+    def stop_server
+      server.shutdown
+    end
+
+    def static_file_dir
+      unless File.directory?(@static_file_dir)
+        FileUtils.mkdir_p(@static_file_dir)
+      end
+      @static_file_dir
+    end
+
+    def compile_template
+      template = File.open(@template)
+      File.open("#{static_file_dir}/index.html", "w") do |f|
+        renderer = ERB.new(template.read)
+        f << renderer.result()
+      end
+    end
+  end
+end
+

--- a/vantiv-ruby.gemspec
+++ b/vantiv-ruby.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency 'selenium-webdriver'
+  spec.add_development_dependency 'webrick'
 end


### PR DESCRIPTION
* Vantiv Cert API underwent a change where paypageRegistrationIds are
  now specific to the paypage id given to merchant accounts - e.g. temp
  tokens retrieved from example paypage previously used in test no
  longer can be tokenized in merchant account
* Adds a TestPaypageServer to serve a mock Vantiv paypage with eprotect
  iframe
* Enables retrieval of paypageRegistrationIds from Vantiv API