### PR TITLE
Implement direct tokenization of card data:

### DIFF
--- a/cert_fixtures/L_T_1.json
+++ b/cert_fixtures/L_T_1.json
@@ -1,0 +1,11 @@
+{
+  "endpoint": "TOKENIZATION",
+  "body": {
+    "Transaction": {
+      "CustomerID": "123"
+    },
+    "Card": {
+      "AccountNumber": "4457119922390123"
+    }
+  }
+}

--- a/cert_fixtures/L_T_10.json
+++ b/cert_fixtures/L_T_10.json
@@ -1,0 +1,19 @@
+{
+  "endpoint": "AUTHORIZATION",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "150.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "ExpirationMonth": "11",
+      "ExpirationYear": "16"
+    },
+    "PaymentAccount": {
+      "PaymentAccountID": "1111000100092332"
+    }
+  }
+}

--- a/cert_fixtures/L_T_11.json
+++ b/cert_fixtures/L_T_11.json
@@ -1,0 +1,19 @@
+{
+  "endpoint": "AUTHORIZATION",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "150.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "ExpirationMonth": "11",
+      "ExpirationYear": "16"
+    },
+    "PaymentAccount": {
+      "PaymentAccountID": "1112000100000085"
+    }
+  }
+}

--- a/cert_fixtures/L_T_2.json
+++ b/cert_fixtures/L_T_2.json
@@ -1,0 +1,11 @@
+{
+  "endpoint": "TOKENIZATION",
+  "body": {
+    "Transaction": {
+      "CustomerID": "123"
+    },
+    "Card": {
+      "AccountNumber": "4457119999999999"
+    }
+  }
+}

--- a/cert_fixtures/L_T_3.json
+++ b/cert_fixtures/L_T_3.json
@@ -1,0 +1,12 @@
+{
+  "endpoint": "TOKENIZATION",
+  "body": {
+    "Transaction": {
+      "CustomerID": "123"
+    },
+    "Card": {
+      "AccountNumber": "4457119922390123"
+    }
+
+  }
+}

--- a/cert_fixtures/L_T_4.json
+++ b/cert_fixtures/L_T_4.json
@@ -1,0 +1,11 @@
+{
+  "endpoint": "TOKENIZATION",
+  "body": {
+    "Transaction": {
+      "CustomerID": "123"
+    },
+    "Card": {
+      "AccountNumber": "4457119922390123"
+    }
+  }
+}

--- a/cert_fixtures/L_T_6.json
+++ b/cert_fixtures/L_T_6.json
@@ -1,0 +1,19 @@
+{
+  "endpoint": "AUTHORIZATION",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "150.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5435101234510196",
+      "ExpirationMonth": "11",
+      "ExpirationYear": "16",
+      "CVV": "987"
+    }
+  }
+}

--- a/cert_fixtures/L_T_7.json
+++ b/cert_fixtures/L_T_7.json
@@ -1,0 +1,19 @@
+{
+  "endpoint": "AUTHORIZATION",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "150.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5435109999999999",
+      "ExpirationMonth": "11",
+      "ExpirationYear": "16",
+      "CVV": "987"
+    }
+  }
+}

--- a/cert_fixtures/L_T_8.json
+++ b/cert_fixtures/L_T_8.json
@@ -1,0 +1,19 @@
+{
+  "endpoint": "AUTHORIZATION",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "150.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "Type": "MC",
+      "CardNumber": "5435101234510196",
+      "ExpirationMonth": "11",
+      "ExpirationYear": "16",
+      "CVV": "987"
+    }
+  }
+}

--- a/cert_fixtures/L_T_9.json
+++ b/cert_fixtures/L_T_9.json
@@ -1,0 +1,20 @@
+{
+  "endpoint": "AUTHORIZATION",
+  "body": {
+    "Transaction": {
+      "ReferenceNumber": "1",
+      "TransactionAmount": "150.00",
+      "OrderSource": "ecommerce",
+      "CustomerID": "345",
+      "PartialApprovedFlag": "false"
+    },
+    "Card": {
+      "ExpirationMonth": "11",
+      "ExpirationYear": "16",
+      "CVV": "987"
+    },
+    "PaymentAccount": {
+      "PaymentAccountID": "#{L_T_8.litleOnlineResponse.authorizationResponse.tokenResponse.PaymentAccountID}"
+    }
+  }
+}

--- a/lib/vantiv.rb
+++ b/lib/vantiv.rb
@@ -20,6 +20,20 @@ module Vantiv
     ).run
   end
 
+  def self.tokenize_by_direct_post(card_number:, expiry_month:, expiry_year:, cvv:)
+    body = Api::RequestBody.for_direct_post_tokenization(
+      card_number: card_number,
+      expiry_month: expiry_month,
+      expiry_year: expiry_year,
+      cvv: cvv
+    )
+    Api::Request.new(
+      endpoint: Api::Endpoints::TOKENIZATION,
+      body: body,
+      response_object: Api::TokenizationResponse.new
+    ).run
+  end
+
   def self.auth(amount:, payment_account_id:, customer_id:, order_id:)
     body = Api::RequestBody.for_auth_or_sale(
       amount: amount,

--- a/lib/vantiv/api/live_transaction_response.rb
+++ b/lib/vantiv/api/live_transaction_response.rb
@@ -5,6 +5,7 @@ module Vantiv
         approved: '000',
         insufficient_funds: '110',
         invalid_account_number: '301',
+        expired_card: '305',
         token_not_found: '822'
       }
 
@@ -33,6 +34,10 @@ module Vantiv
 
       def invalid_account_number?
         response_code == RESPONSE_CODES[:invalid_account_number]
+      end
+
+      def expired_card?
+        response_code == RESPONSE_CODES[:expired_card]
       end
 
       private

--- a/lib/vantiv/api/request_body.rb
+++ b/lib/vantiv/api/request_body.rb
@@ -43,6 +43,19 @@ module Vantiv
         )
       end
 
+      def self.for_direct_post_tokenization(card_number:, expiry_month:, expiry_year:, cvv:)
+        RequestBodyGenerator.run(
+          {
+            "Card" => {
+              "AccountNumber" => card_number,
+              "ExpirationMonth" => expiry_month,
+              "ExpirationYear" => expiry_year,
+              "CVV" => cvv
+            }
+          }
+        )
+      end
+
       def self.for_void(transaction_id:)
         RequestBodyGenerator.run(tied_transaction_element(transaction_id: transaction_id))
       end

--- a/lib/vantiv/api/tokenization_response.rb
+++ b/lib/vantiv/api/tokenization_response.rb
@@ -2,7 +2,7 @@ require 'pry'
 module Vantiv
   module Api
     class TokenizationResponse < Api::Response
-      ResponseCodes = {
+      RESPONSE_CODES = {
         account_successfully_registered: "801",
         account_already_registered: "802",
         credit_card_number_invalid: "820",
@@ -27,11 +27,15 @@ module Vantiv
         success? ? litle_transaction_response["PaymentAccountID"] : nil
       end
 
+      def invalid_card_number?
+        response_code == RESPONSE_CODES[:credit_card_number_invalid]
+      end
+
       private
 
       def tokenization_successful?
-        response_code == ResponseCodes[:account_successfully_registered] ||
-          response_code == ResponseCodes[:account_already_registered]
+        response_code == RESPONSE_CODES[:account_successfully_registered] ||
+          response_code == RESPONSE_CODES[:account_already_registered]
       end
 
       def transaction_response_name

--- a/spec/direct_tokenization_spec.rb
+++ b/spec/direct_tokenization_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+describe "directly tokenizing card data" do
+  let(:response) do
+    Vantiv.tokenize_by_direct_post(
+      card_number: card.card_number,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year,
+      cvv: card.cvv
+    )
+  end
+
+  context "with a valid account number" do
+    let(:card) { Vantiv::TestAccount.valid_account }
+
+    it "returns success" do
+      expect(response.success?).to eq true
+    end
+
+    it "returns a payment account id" do
+      expect(response.payment_account_id).not_to eq nil
+      expect(response.payment_account_id).not_to eq ""
+    end
+
+    it "enables using the payment account id for subsequent transactions" do
+      payment_account_id = response.payment_account_id
+
+      auth_response = Vantiv.auth(
+        amount: 10000,
+        payment_account_id: payment_account_id,
+        customer_id: "doesntmatter",
+        order_id: "orderblah"
+      )
+      expect(auth_response.success?).to eq true
+    end
+  end
+
+  context "when the credit card number is completely invalid" do
+    let(:card) { Vantiv::TestAccount.invalid_card_number }
+
+    it "returns failure" do
+      expect(response.success?).to eq false
+      expect(response.failure?).to eq true
+    end
+
+    it "does not return a payment account id" do
+      expect(response.payment_account_id).to eq nil
+    end
+
+    it "reveals that the card number was invalid" do
+      expect(response.invalid_card_number?).to eq true
+    end
+
+    it "returns a human readable message" do
+      expect(response.message).to match(/credit card number was invalid/i)
+    end
+  end
+
+  context "when the credit card is expired" do
+    let(:card) { Vantiv::TestAccount.expired }
+
+    it "returns success" do
+      expect(response.success?).to eq true
+    end
+
+    it "returns a payment account id" do
+      expect(response.payment_account_id).not_to eq nil
+      expect(response.payment_account_id).not_to eq ""
+    end
+
+    it "only reveals account expired issue on subsequent transactions" do
+      payment_account_id = response.payment_account_id
+
+      auth_response = Vantiv.auth(
+        amount: 10000,
+        payment_account_id: payment_account_id,
+        customer_id: "doesntmatter",
+        order_id: "orderblah"
+      )
+      expect(auth_response.success?).to eq false
+      expect(auth_response.expired_card?).to eq true
+    end
+  end
+
+  context "with an account with an invalid account number" do
+    let(:card) { Vantiv::TestAccount.invalid_account_number }
+
+    it "returns success" do
+      expect(response.success?).to eq true
+    end
+
+    it "returns a payment account id" do
+      expect(response.payment_account_id).not_to eq nil
+      expect(response.payment_account_id).not_to eq ""
+    end
+
+    it "only reveals account validity issue on subsequent transactions" do
+      payment_account_id = response.payment_account_id
+
+      auth_response = Vantiv.auth(
+        amount: 10000,
+        payment_account_id: payment_account_id,
+        customer_id: "doesntmatter",
+        order_id: "orderblah"
+      )
+      expect(auth_response.success?).to eq false
+      expect(auth_response.invalid_account_number?).to eq true
+    end
+  end
+end

--- a/spec/e_protect_spec.rb
+++ b/spec/e_protect_spec.rb
@@ -118,7 +118,7 @@ describe "promoting a temporary token to a permanent token" do
 
     it "returns a corresponding response code" do
       expect(response.response_code).to eq(
-        Vantiv::Api::TokenizationResponse::ResponseCodes[:invalid_paypage_registration_id]
+        Vantiv::Api::TokenizationResponse::RESPONSE_CODES[:invalid_paypage_registration_id]
       )
     end
 

--- a/spec/support/test_account.rb
+++ b/spec/support/test_account.rb
@@ -30,6 +30,19 @@ module Vantiv
       )
     end
 
+    def self.invalid_card_number
+      new("4716605112879585", "01", "2020", "123")
+    end
+
+    def self.expired
+      fetch_account(
+        card_number: "5112001900000003",
+        expiry_month: "01",
+        expiry_year: "2020",
+        cvv: "123"
+      )
+    end
+
     def self.invalid_account_number
       fetch_account(
         card_number: "5112010100000002",


### PR DESCRIPTION
* Allows merchants to submit card data directly to Vantiv
* For simplest PCI compliance, eProtect should still be used. Direct
  tokenization can be used to manage a transition to eProtect though

Waiting for certification for merge.