### PR TITLE
Retry requests when Vantiv doesn't respond with JSON:

### DIFF
--- a/lib/vantiv/api/request.rb
+++ b/lib/vantiv/api/request.rb
@@ -7,10 +7,12 @@ module Vantiv
       @endpoint = endpoint
       @body = body.to_json
       @response_object = response_object
+      self.retry_count = 0
     end
 
     def run
-      response_object.load(run_request)
+      vantiv_response = run_request_with_retries
+      response_object.load(vantiv_response)
       response_object
     end
 
@@ -21,16 +23,18 @@ module Vantiv
       request = Net::HTTP::Post.new(uri.request_uri, header)
       request.body = body
       raw_response = http.request(request)
+      parsed_body = JSON.parse(raw_response.body)
       {
         httpok: raw_response.code_type == Net::HTTPOK,
         http_response_code: raw_response.code,
-        raw_body: raw_response.body
+        body: parsed_body
       }
     end
 
     private
 
     attr_reader :endpoint, :response_object
+    attr_accessor :retry_count
 
     def header
       {
@@ -48,6 +52,23 @@ module Vantiv
         "https://apis.vantiv.com"
       elsif Vantiv::Environment.certification?
         "https://apis.cert.vantiv.com"
+      end
+    end
+
+    def max_retries_exceeded?
+      retry_count > 3
+    end
+
+    def run_request_with_retries
+      begin
+        run_request
+      rescue JSON::ParserError => e
+        self.retry_count += 1
+        if max_retries_exceeded?
+          raise e
+        else
+          run_request_with_retries
+        end
       end
     end
   end

--- a/lib/vantiv/api/response.rb
+++ b/lib/vantiv/api/response.rb
@@ -3,10 +3,10 @@ module Vantiv
     class Response
       attr_reader :httpok, :http_response_code, :body
 
-      def load(httpok:, http_response_code:, raw_body:)
+      def load(httpok:, http_response_code:, body:)
         @httpok = httpok
         @http_response_code = http_response_code
-        @body = JSON.parse(raw_body)
+        @body = body
       end
 
       # Only returned by cert API?

--- a/lib/vantiv/mocked_sandbox/api_request.rb
+++ b/lib/vantiv/mocked_sandbox/api_request.rb
@@ -21,7 +21,7 @@ module Vantiv
         {
           httpok: fixture["httpok"],
           http_response_code: fixture["http_response_code"],
-          raw_body: ERB.new(fixture["response_body"]).result(binding)
+          body: JSON.parse(ERB.new(fixture["response_body"]).result(binding))
         }
       end
 

--- a/spec/api/request_spec.rb
+++ b/spec/api/request_spec.rb
@@ -44,4 +44,27 @@ describe Vantiv::Api::Request do
       expect(run_api_request.api_level_failure?).to eq true
     end
   end
+
+  context "when Vantiv (conveniently) doesn't send back json" do
+
+    it "retries the original request" do
+      vantiv_responses = [
+        double(
+          code_type: Net::HTTPOK,
+          code: "200",
+          body: ""
+        ),
+        double(
+          code_type: Net::HTTPOK,
+          code: "200",
+          body: {something: "in json"}.to_json
+        )
+      ]
+      allow_any_instance_of(Net::HTTP).to receive(:request) { vantiv_responses.shift }
+      expect{
+        @response = run_api_request
+      }.not_to raise_error
+      expect(@response.body).to eq({"something" => "in json"})
+    end
+  end
 end


### PR DESCRIPTION
* Sometimes requests to Vantiv's API returns non-JSON responses
* In that case, we expect that the entirely have not served the original
  request
* So we retry