### PR TITLE
Don't let rails overriding #to_json break mocking requests

### DIFF
--- a/lib/vantiv/mocked_sandbox/api_request.rb
+++ b/lib/vantiv/mocked_sandbox/api_request.rb
@@ -65,7 +65,11 @@ module Vantiv
         begin
           self.fixture = File.open("#{MockedSandbox.fixtures_directory}#{fixture_file_name}.json.erb", 'r') do |f|
             raw_fixture = JSON.parse(f.read)
-            raw_fixture["response_body"] = raw_fixture["response_body"].to_json
+            # Prevent rails overridden version of to_json from encoding erb sepcial characters
+            raw_fixture["response_body"] = JSON::Ext::Generator::GeneratorMethods::Hash
+              .instance_method(:to_json)
+              .bind(raw_fixture["response_body"])
+              .call
             raw_fixture
           end
         rescue Errno::ENOENT

--- a/spec/mocked_sandbox/api_request_spec.rb
+++ b/spec/mocked_sandbox/api_request_spec.rb
@@ -13,15 +13,19 @@ describe Vantiv::MockedSandbox::ApiRequest do
     )
   end
 
+  let(:body) do
+    Vantiv::Api::RequestBody.for_direct_post_tokenization(
+      card_number: card.card_number,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year,
+      cvv: card.cvv
+    ).to_json
+  end
+
   let(:run_mocked_request) {
     Vantiv::MockedSandbox::ApiRequest.run(
       endpoint: Vantiv::Api::Endpoints::TOKENIZATION,
-      body: Vantiv::Api::RequestBody.for_direct_post_tokenization(
-        card_number: card.card_number,
-        expiry_month: card.expiry_month,
-        expiry_year: card.expiry_year,
-        cvv: card.cvv
-      ).to_json
+      body: body
     )
   }
 
@@ -29,5 +33,21 @@ describe Vantiv::MockedSandbox::ApiRequest do
     expect{
       run_mocked_request
     }.to raise_error(/Fixture not found/)
+  end
+
+  context "when to_json is overridden (rails...)" do
+    let(:card) { Vantiv::TestCard.valid_account }
+
+    before do
+      body
+      allow_any_instance_of(Hash).to receive(:to_json)
+        .and_return({ something: "bad" })
+    end
+
+    it "returns the correct response body" do
+      response_body = run_mocked_request[:body]
+      expect(response_body["litleOnlineResponse"]).to be
+      expect(response_body[:something]).to be_nil
+    end
   end
 end


### PR DESCRIPTION
This change forces the gem to call the ruby verison of to_json, rather than Rails' overridden version which encodes special characters and causes ERB not to be evaluated correctly. Kinda messy, but it works.