### PR TITLE
Make amount in credit transaction optional:

### DIFF
--- a/lib/vantiv.rb
+++ b/lib/vantiv.rb
@@ -93,7 +93,7 @@ module Vantiv
 
   # NOTE: ActiveMerchant's #refund... only for use on a capture or sale it seems
   #       -> 'returns' are refunds too, credits are tied to a sale/capture, returns can be willy nilly
-  def self.credit(transaction_id:, amount:)
+  def self.credit(transaction_id:, amount: nil)
     body = Api::RequestBody.for_credit(
       amount: amount,
       transaction_id: transaction_id


### PR DESCRIPTION
* With no amount passed, a credit transaction will give the customer
  back the full amount of the original transaction