### PR TITLE
Speed up test suite by running fewer requests in mocked sandbox tests:

### DIFF
--- a/spec/mocked_sandbox/auth_capture_spec.rb
+++ b/spec/mocked_sandbox/auth_capture_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include TestHelpers
 
 describe "mocked API requests to auth_capture" do
   let(:payment_account_id) { card.mocked_sandbox_payment_account_id }
@@ -45,13 +46,22 @@ describe "mocked API requests to auth_capture" do
     let(:card) { test_card }
 
     context "with a #{test_card.name}" do
-      (
-        Vantiv::Api::LiveTransactionResponse.instance_methods(false) +
-        Vantiv::Api::Response.instance_methods(false) -
-        [:payment_account_id, :body, :load, :request_id, :transaction_id]
-      ).each do |method_name|
-        it "the mocked response returns the same as the live one for ##{method_name}" do
-          expect(mocked_response.send(method_name)).to eq live_response.send(method_name)
+      it "the mocked response's public methods return the same as the live one" do
+        (
+          Vantiv::Api::LiveTransactionResponse.instance_methods(false) +
+          Vantiv::Api::Response.instance_methods(false) -
+          [:payment_account_id, :body, :load, :request_id, :transaction_id]
+        ).each do |method_name|
+          live_response_value = live_response.send(method_name)
+          mocked_response_value = mocked_response.send(method_name)
+
+          expect(mocked_response_value).to eq(live_response_value),
+            error_message_for_mocked_api_failure(
+              method_name: method_name,
+              expected_value: live_response_value,
+              got_value: mocked_response_value,
+              live_response: live_response
+            )
         end
       end
 

--- a/spec/mocked_sandbox/auth_reversal_spec.rb
+++ b/spec/mocked_sandbox/auth_reversal_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include TestHelpers
 
 describe "mocked API requests to auth_reversal" do
   let(:live_sandbox_payment_account_id) do
@@ -51,13 +52,22 @@ describe "mocked API requests to auth_reversal" do
     let(:card) { test_card }
 
     context "with a #{test_card.name}" do
-      (
-        Vantiv::Api::TiedTransactionResponse.instance_methods(false) +
-        Vantiv::Api::Response.instance_methods(false) -
-        [:payment_account_id, :body, :load, :request_id, :transaction_id]
-      ).each do |method_name|
-        it "the mocked response returns the same as the live one for ##{method_name}" do
-          expect(mocked_response.send(method_name)).to eq live_response.send(method_name)
+      it "the mocked response's public methods return the same as the live one" do
+        (
+          Vantiv::Api::TiedTransactionResponse.instance_methods(false) +
+          Vantiv::Api::Response.instance_methods(false) -
+          [:payment_account_id, :body, :load, :request_id, :transaction_id]
+        ).each do |method_name|
+          live_response_value = live_response.send(method_name)
+          mocked_response_value = mocked_response.send(method_name)
+
+          expect(mocked_response_value).to eq(live_response_value),
+            error_message_for_mocked_api_failure(
+              method_name: method_name,
+              expected_value: live_response_value,
+              got_value: mocked_response_value,
+              live_response: live_response
+            )
         end
       end
 

--- a/spec/mocked_sandbox/capture_spec.rb
+++ b/spec/mocked_sandbox/capture_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include TestHelpers
 
 describe "mocked API requests to capture" do
   let(:live_sandbox_payment_account_id) do
@@ -53,13 +54,22 @@ describe "mocked API requests to capture" do
     let(:card) { test_card }
 
     context "with a #{test_card.name}" do
-      (
-        Vantiv::Api::TiedTransactionResponse.instance_methods(false) +
-        Vantiv::Api::Response.instance_methods(false) -
-        [:payment_account_id, :body, :load, :request_id, :transaction_id]
-      ).each do |method_name|
-        it "the mocked response returns the same as the live one for ##{method_name}" do
-          expect(mocked_response.send(method_name)).to eq live_response.send(method_name)
+      it "the mocked response's public methods return the same as the live one" do
+        (
+          Vantiv::Api::TiedTransactionResponse.instance_methods(false) +
+          Vantiv::Api::Response.instance_methods(false) -
+          [:payment_account_id, :body, :load, :request_id, :transaction_id]
+        ).each do |method_name|
+          live_response_value = live_response.send(method_name)
+          mocked_response_value = mocked_response.send(method_name)
+
+          expect(mocked_response_value).to eq(live_response_value),
+            error_message_for_mocked_api_failure(
+              method_name: method_name,
+              expected_value: live_response_value,
+              got_value: mocked_response_value,
+              live_response: live_response
+            )
         end
       end
 

--- a/spec/mocked_sandbox/credit_spec.rb
+++ b/spec/mocked_sandbox/credit_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include TestHelpers
 
 describe "mocked API requests to credit" do
   let(:live_sandbox_payment_account_id) do
@@ -54,13 +55,22 @@ describe "mocked API requests to credit" do
     let(:card) { test_card }
 
     context "with a #{test_card.name}" do
+      it "the mocked response's public methods return the same as the live one" do
       (
         Vantiv::Api::TiedTransactionResponse.instance_methods(false) +
         Vantiv::Api::Response.instance_methods(false) -
         [:payment_account_id, :body, :load, :request_id, :transaction_id]
       ).each do |method_name|
-        it "the mocked response returns the same as the live one for ##{method_name}" do
-          expect(mocked_response.send(method_name)).to eq live_response.send(method_name)
+          live_response_value = live_response.send(method_name)
+          mocked_response_value = mocked_response.send(method_name)
+
+          expect(mocked_response_value).to eq(live_response_value),
+            error_message_for_mocked_api_failure(
+              method_name: method_name,
+              expected_value: live_response_value,
+              got_value: mocked_response_value,
+              live_response: live_response
+            )
         end
       end
 

--- a/spec/mocked_sandbox/refund_spec.rb
+++ b/spec/mocked_sandbox/refund_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include TestHelpers
 
 describe "mocked API requests to refund" do
   let(:live_sandbox_payment_account_id) do
@@ -44,13 +45,22 @@ describe "mocked API requests to refund" do
     let(:card) { test_card }
 
     context "with a #{test_card.name}" do
+      it "the mocked response's public methods return the same as the live one" do
       (
         Vantiv::Api::TiedTransactionResponse.instance_methods(false) +
         Vantiv::Api::Response.instance_methods(false) -
         [:payment_account_id, :body, :load, :request_id, :transaction_id]
       ).each do |method_name|
-        it "the mocked response returns the same as the live one for ##{method_name}" do
-          expect(mocked_response.send(method_name)).to eq live_response.send(method_name)
+          live_response_value = live_response.send(method_name)
+          mocked_response_value = mocked_response.send(method_name)
+
+          expect(mocked_response_value).to eq(live_response_value),
+            error_message_for_mocked_api_failure(
+              method_name: method_name,
+              expected_value: live_response_value,
+              got_value: mocked_response_value,
+              live_response: live_response
+            )
         end
       end
 

--- a/spec/mocked_sandbox/tokenize_by_direct_post_spec.rb
+++ b/spec/mocked_sandbox/tokenize_by_direct_post_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include TestHelpers
 
 describe "mocked API requests to tokenize_by_direct_post" do
   def run_mocked_response
@@ -29,13 +30,22 @@ describe "mocked API requests to tokenize_by_direct_post" do
     let(:card) { test_card }
 
     context "with a #{test_card.name}" do
+      it "the mocked response's public methods return the same as the live one" do
       (
         Vantiv::Api::TokenizationResponse.instance_methods(false) +
         Vantiv::Api::Response.instance_methods(false) -
         [:payment_account_id, :body, :load, :request_id, :transaction_id]
       ).each do |method_name|
-        it "the mocked response returns the same as the live one for ##{method_name}" do
-          expect(mocked_response.send(method_name)).to eq live_response.send(method_name)
+          live_response_value = live_response.send(method_name)
+          mocked_response_value = mocked_response.send(method_name)
+
+          expect(mocked_response_value).to eq(live_response_value),
+            error_message_for_mocked_api_failure(
+              method_name: method_name,
+              expected_value: live_response_value,
+              got_value: mocked_response_value,
+              live_response: live_response
+            )
         end
       end
 

--- a/spec/mocked_sandbox/void_spec.rb
+++ b/spec/mocked_sandbox/void_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+include TestHelpers
 
 describe "mocked API requests to void" do
   let(:live_sandbox_payment_account_id) do
@@ -51,13 +52,22 @@ describe "mocked API requests to void" do
     let(:card) { test_card }
 
     context "with a #{test_card.name}" do
-      (
-        Vantiv::Api::TiedTransactionResponse.instance_methods(false) +
-        Vantiv::Api::Response.instance_methods(false) -
-        [:payment_account_id, :body, :load, :request_id, :transaction_id]
-      ).each do |method_name|
-        it "the mocked response returns the same as the live one for ##{method_name}" do
-          expect(mocked_response.send(method_name)).to eq live_response.send(method_name)
+      it "the mocked response's public methods return the same as the live one" do
+        (
+          Vantiv::Api::TiedTransactionResponse.instance_methods(false) +
+          Vantiv::Api::Response.instance_methods(false) -
+          [:payment_account_id, :body, :load, :request_id, :transaction_id]
+        ).each do |method_name|
+          live_response_value = live_response.send(method_name)
+          mocked_response_value = mocked_response.send(method_name)
+
+          expect(mocked_response_value).to eq(live_response_value),
+            error_message_for_mocked_api_failure(
+              method_name: method_name,
+              expected_value: live_response_value,
+              got_value: mocked_response_value,
+              live_response: live_response
+          )
         end
       end
 

--- a/spec/support/mocked_api.rb
+++ b/spec/support/mocked_api.rb
@@ -1,0 +1,7 @@
+module TestHelpers
+  def error_message_for_mocked_api_failure(method_name:, expected_value:, got_value:, live_response:)
+    "Expected ##{method_name} to return #{expected_value}, got #{got_value}\n
+     Live response code: #{live_response.response_code}, msg: #{live_response.message}\n
+     (Check that Cert API is not having stabilty issues)"
+  end
+end


### PR DESCRIPTION
* Was running one request per public method expectation
* Instead, now run all public method expecations inside one test, with
  custom error message so that it remains clear what the failure is