### PR TITLE
Send expiration data on live transactions:

### DIFF
--- a/cert_fixtures/L_EP_2.json
+++ b/cert_fixtures/L_EP_2.json
@@ -9,7 +9,9 @@
       "PartialApprovedFlag": "false"
     },
     "Card": {
-      "PaypageRegistrationID": "${eProtect.5435101234510196}"
+      "PaypageRegistrationID": "${eProtect.5435101234510196}",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16"
     }
   }
 }

--- a/cert_fixtures/L_EP_3.json
+++ b/cert_fixtures/L_EP_3.json
@@ -2,7 +2,9 @@
   "endpoint": "TOKENIZATION",
   "body": {
     "Card": {
-      "PaypageRegistrationID": "${eProtect.6011010140000004}"
+      "PaypageRegistrationID": "${eProtect.6011010140000004}",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16"
     },
     "Transaction": {
       "CustomerID": "123"

--- a/cert_fixtures/L_EP_4.json
+++ b/cert_fixtures/L_EP_4.json
@@ -10,6 +10,10 @@
     },
     "PaymentAccount": {
       "PaymentAccountID": "#{L_EP_1.litleOnlineResponse.authorizationResponse.tokenResponse.PaymentAccountID}"
+    },
+    "Card": {
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16"
     }
   }
 }

--- a/cert_fixtures/L_EP_5.json
+++ b/cert_fixtures/L_EP_5.json
@@ -10,6 +10,10 @@
     },
     "PaymentAccount": {
       "PaymentAccountID": "#{L_EP_2.litleOnlineResponse.saleResponse.tokenResponse.PaymentAccountID}"
+    },
+    "Card": {
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16"
     }
   }
 }

--- a/cert_fixtures/L_EP_6.json
+++ b/cert_fixtures/L_EP_6.json
@@ -9,7 +9,9 @@
       "PartialApprovedFlag": "false"
     },
     "Card": {
-      "PaypageRegistrationID": "cDZJcmd1VjNlYXNaSlRMTGpocVZQY1NWVXE4ZW5UTko4NU9KK3p1L1p1Vzg4YzVPQVlSUHNITG1JN2I0NzlyTg=="
+      "PaypageRegistrationID": "cDZJcmd1VjNlYXNaSlRMTGpocVZQY1NWVXE4ZW5UTko4NU9KK3p1L1p1Vzg4YzVPQVlSUHNITG1JN2I0NzlyTg==",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16"
     }
   }
 }

--- a/cert_fixtures/L_EP_7.json
+++ b/cert_fixtures/L_EP_7.json
@@ -9,7 +9,9 @@
       "PartialApprovedFlag": "false"
     },
     "Card": {
-      "PaypageRegistrationID": "RGFQNCt6U1d1M21SeVByVTM4dHlHb1FsVkUrSmpnWXhNY0o5UkMzRlZFanZiUHVnYjN1enJXbG1WSDF4aXlNcA=="
+      "PaypageRegistrationID": "RGFQNCt6U1d1M21SeVByVTM4dHlHb1FsVkUrSmpnWXhNY0o5UkMzRlZFanZiUHVnYjN1enJXbG1WSDF4aXlNcA==",
+      "ExpirationMonth": "01",
+      "ExpirationYear": "16"
     }
   }
 }

--- a/exe/vantiv-certify-app
+++ b/exe/vantiv-certify-app
@@ -11,6 +11,7 @@ Vantiv.configure do |config|
   config.license_id = ENV["LICENSE_ID"]
   config.acceptor_id = ENV["ACCEPTOR_ID"]
   config.paypage_id = ENV["PAYPAGE_ID"]
+  config.environment = Vantiv::Environment::CERTIFICATION
 
   config.default_report_group = '1'
 end

--- a/lib/vantiv.rb
+++ b/lib/vantiv.rb
@@ -37,12 +37,14 @@ module Vantiv
     ).run
   end
 
-  def self.auth(amount:, payment_account_id:, customer_id:, order_id:)
+  def self.auth(amount:, payment_account_id:, customer_id:, order_id:, expiry_month:, expiry_year:)
     body = Api::RequestBody.for_auth_or_sale(
       amount: amount,
       order_id: order_id,
       customer_id: customer_id,
-      payment_account_id: payment_account_id
+      payment_account_id: payment_account_id,
+      expiry_month: expiry_month,
+      expiry_year: expiry_year
     )
     Api::Request.new(
       endpoint: Api::Endpoints::AUTHORIZATION,
@@ -77,12 +79,14 @@ module Vantiv
     ).run
   end
 
-  def self.auth_capture(amount:, payment_account_id:, customer_id:, order_id:)
+  def self.auth_capture(amount:, payment_account_id:, customer_id:, order_id:, expiry_month:, expiry_year:)
     body = Api::RequestBody.for_auth_or_sale(
       amount: amount,
       order_id: order_id,
       customer_id: customer_id,
-      payment_account_id: payment_account_id
+      payment_account_id: payment_account_id,
+      expiry_month: expiry_month,
+      expiry_year: expiry_year
     )
     Api::Request.new(
       endpoint: Api::Endpoints::SALE,
@@ -105,12 +109,14 @@ module Vantiv
     ).run
   end
 
-  def self.refund(amount:, payment_account_id:, customer_id:, order_id:)
+  def self.refund(amount:, payment_account_id:, customer_id:, order_id:, expiry_month:, expiry_year:)
     body = Api::RequestBody.for_return(
       amount: amount,
       customer_id: customer_id,
       order_id: order_id,
-      payment_account_id: payment_account_id
+      payment_account_id: payment_account_id,
+      expiry_month: expiry_month,
+      expiry_year: expiry_year
     )
     Api::Request.new(
       endpoint: Api::Endpoints::RETURN,

--- a/spec/api/request_body_spec.rb
+++ b/spec/api/request_body_spec.rb
@@ -18,8 +18,8 @@ describe Vantiv::Api::RequestBody do
 
     it "includes stringified versions of card params" do
       expect(request_body["Card"]["AccountNumber"]).to eq(card_number.to_s)
-      expect(request_body["Card"]["ExpirationMonth"]).to eq(expiry_month.to_s)
-      expect(request_body["Card"]["ExpirationYear"]).to eq(expiry_year.to_s)
+      expect(request_body["Card"]["ExpirationMonth"]).to eq("10")
+      expect(request_body["Card"]["ExpirationYear"]).to eq("18")
       expect(request_body["Card"]["CVV"]).to eq(cvv.to_s)
     end
 
@@ -90,7 +90,9 @@ describe Vantiv::Api::RequestBody do
         amount: 4224,
         customer_id: "extid123",
         payment_account_id: "paymentacct123",
-        order_id: "SomeOrder123"
+        order_id: "SomeOrder123",
+        expiry_month: "8",
+        expiry_year: "2018"
       )
     end
 
@@ -107,9 +109,16 @@ describe Vantiv::Api::RequestBody do
         amount: 4224,
         customer_id: "extid123",
         payment_account_id: "paymentacct123",
-        order_id: 123
+        order_id: 123,
+        expiry_month: "12",
+        expiry_year: "2099"
       )
       expect(body["Transaction"]["ReferenceNumber"]).to eq "123"
+    end
+
+    it "includes expiry data" do
+      expect(request_body["Card"]["ExpirationMonth"]).to eq "08"
+      expect(request_body["Card"]["ExpirationYear"]).to eq "18"
     end
   end
 
@@ -145,6 +154,25 @@ describe Vantiv::Api::RequestBody do
 
     it "includes the merchant reference number for the order (required by Vantiv)" do
       expect(transaction_element["Transaction"]["ReferenceNumber"]).to eq "some-order"
+    end
+  end
+
+  describe ".format_expiry" do
+    it "returns a two digit value if a one digit month is passed" do
+      expect(Vantiv::Api::RequestBody.format_expiry("8")).to eq "08"
+    end
+
+    it "returns a two digit value if two digit value is passed" do
+      expect(Vantiv::Api::RequestBody.format_expiry("08")).to eq "08"
+    end
+
+    it "returns a string if a number is passed" do
+      expect(Vantiv::Api::RequestBody.format_expiry(8)).to eq "08"
+    end
+
+    it "returns the last two digits if a four digit year is passed" do
+      expect(Vantiv::Api::RequestBody.format_expiry("2019")).to eq "19"
+      expect(Vantiv::Api::RequestBody.format_expiry(2019)).to eq "19"
     end
   end
 end

--- a/spec/auth_capture_spec.rb
+++ b/spec/auth_capture_spec.rb
@@ -2,18 +2,21 @@ require 'spec_helper'
 
 describe "auth_capture (Sale)" do
   let(:customer_external_id) { "1234" }
+  let(:payment_account_id) { test_account.payment_account_id }
 
   subject(:run_auth_capture) do
     Vantiv.auth_capture(
       amount: 10000,
       payment_account_id: payment_account_id,
       customer_id: customer_external_id,
-      order_id: "SomeOrder123"
+      order_id: "SomeOrder123",
+      expiry_month: test_account.expiry_month,
+      expiry_year: test_account.expiry_year
     )
   end
 
   context "on a valid account" do
-    let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+    let(:test_account) { Vantiv::TestAccount.valid_account }
 
     it "returns success response" do
       response = run_auth_capture
@@ -33,7 +36,7 @@ describe "auth_capture (Sale)" do
   end
 
   context "on an account with insufficient funds" do
-    let(:payment_account_id) { Vantiv::TestAccount.insufficient_funds.payment_account_id }
+    let(:test_account) { Vantiv::TestAccount.insufficient_funds }
 
     it "returns a failure response" do
       response = run_auth_capture
@@ -64,7 +67,7 @@ describe "auth_capture (Sale)" do
   end
 
   context "on an account with an invalid account number" do
-    let(:payment_account_id) { Vantiv::TestAccount.invalid_account_number.payment_account_id }
+    let(:test_account) { Vantiv::TestAccount.invalid_account_number }
 
     it "returns a failure response" do
       response = run_auth_capture
@@ -95,7 +98,7 @@ describe "auth_capture (Sale)" do
   end
 
   context "on an account with misc errors, like pick up card" do
-    let(:payment_account_id) { Vantiv::TestAccount.pick_up_card.payment_account_id }
+    let(:test_account) { Vantiv::TestAccount.pick_up_card }
 
     it "returns a failure response" do
       response = run_auth_capture
@@ -122,7 +125,7 @@ describe "auth_capture (Sale)" do
   end
 
   context "when API level failure occurs" do
-    let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+    let(:test_account) { Vantiv::TestAccount.valid_account }
 
     before do
       @license_id = Vantiv.license_id

--- a/spec/auth_reversal_spec.rb
+++ b/spec/auth_reversal_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
 
 describe "reversing authorizations" do
-  let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+  let(:test_account) { Vantiv::TestAccount.valid_account }
+  let(:payment_account_id) { test_account.payment_account_id }
   let(:transaction_id) do
     Vantiv.auth(
       amount: 10000,
       payment_account_id: payment_account_id,
       customer_id: "Anything-#{rand(10000)}",
-      order_id: "AnyOrder#{rand(100000)}"
+      order_id: "AnyOrder#{rand(100000)}",
+      expiry_month: test_account.expiry_month,
+      expiry_year: test_account.expiry_year
     ).transaction_id
   end
   let(:amount) { nil }

--- a/spec/authorization_spec.rb
+++ b/spec/authorization_spec.rb
@@ -2,18 +2,21 @@ require 'spec_helper'
 
 describe "auth" do
   let(:customer_external_id) { "1234" }
+  let(:payment_account_id) { test_account.payment_account_id }
 
   subject(:run_auth) do
     Vantiv.auth(
       amount: 10000,
       payment_account_id: payment_account_id,
       customer_id: customer_external_id,
-      order_id: "SomeOrder123"
+      order_id: "SomeOrder123",
+      expiry_month: "01",
+      expiry_year: "16"
     )
   end
 
   context "on a valid account" do
-    let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+    let(:test_account) { Vantiv::TestAccount.valid_account }
 
     it "returns success response" do
       response = run_auth
@@ -33,7 +36,7 @@ describe "auth" do
   end
 
   context "on an account with insufficient funds" do
-    let(:payment_account_id) { Vantiv::TestAccount.insufficient_funds.payment_account_id }
+    let(:test_account) { Vantiv::TestAccount.insufficient_funds }
 
     it "returns a failure response" do
       response = run_auth
@@ -64,7 +67,7 @@ describe "auth" do
   end
 
   context "on an account with an invalid account number" do
-    let(:payment_account_id) { Vantiv::TestAccount.invalid_account_number.payment_account_id }
+    let(:test_account) { Vantiv::TestAccount.invalid_account_number }
 
     it "returns a failure response" do
       response = run_auth
@@ -95,7 +98,7 @@ describe "auth" do
   end
 
   context "on an account with misc errors, like pick up card" do
-    let(:payment_account_id) { Vantiv::TestAccount.pick_up_card.payment_account_id }
+    let(:test_account) { Vantiv::TestAccount.pick_up_card }
 
     it "returns a failure response" do
       response = run_auth
@@ -122,7 +125,7 @@ describe "auth" do
   end
 
   context "when API level failure occurs" do
-    let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+    let(:test_account) { Vantiv::TestAccount.valid_account }
 
     before do
       @license_id = Vantiv.license_id

--- a/spec/capture_spec.rb
+++ b/spec/capture_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
 
 describe "capturing authorizations" do
-  let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+  let(:test_account) { Vantiv::TestAccount.valid_account }
+  let(:payment_account_id) { test_account.payment_account_id }
   let(:transaction_id) do
     Vantiv.auth(
       amount: 10000,
       payment_account_id: payment_account_id,
       customer_id: "Anything-#{rand(10000)}",
-      order_id: "AnyOrder#{rand(100000)}"
+      order_id: "AnyOrder#{rand(100000)}",
+      expiry_month: test_account.expiry_month,
+      expiry_year: test_account.expiry_year
     ).transaction_id
   end
 

--- a/spec/credit_spec.rb
+++ b/spec/credit_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe "processing credits (refunds) on prior transactions" do
-  let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+  let(:test_account) { Vantiv::TestAccount.valid_account }
+  let(:payment_account_id) { test_account.payment_account_id }
   let(:customer_id) { "cust-id-123" }
   let(:order_id) { "order-#{rand(10000)}" }
 
@@ -18,7 +19,9 @@ describe "processing credits (refunds) on prior transactions" do
         amount: 14100,
         customer_id: customer_id,
         order_id: order_id,
-        payment_account_id: payment_account_id
+        payment_account_id: payment_account_id,
+        expiry_month: test_account.expiry_month,
+        expiry_year: test_account.expiry_year
       )
       Vantiv.capture(transaction_id: auth_response.transaction_id)
     end
@@ -51,7 +54,9 @@ describe "processing credits (refunds) on prior transactions" do
         amount: 14100,
         customer_id: customer_id,
         order_id: order_id,
-        payment_account_id: payment_account_id
+        payment_account_id: payment_account_id,
+        expiry_month: test_account.expiry_month,
+        expiry_year: test_account.expiry_year
       )
     end
 

--- a/spec/direct_tokenization_spec.rb
+++ b/spec/direct_tokenization_spec.rb
@@ -29,7 +29,9 @@ describe "directly tokenizing card data" do
         amount: 10000,
         payment_account_id: payment_account_id,
         customer_id: "doesntmatter",
-        order_id: "orderblah"
+        order_id: "orderblah",
+        expiry_month: card.expiry_month,
+        expiry_year: card.expiry_year
       )
       expect(auth_response.success?).to eq true
     end
@@ -83,7 +85,9 @@ describe "directly tokenizing card data" do
         amount: 10000,
         payment_account_id: payment_account_id,
         customer_id: "doesntmatter",
-        order_id: "orderblah"
+        order_id: "orderblah",
+        expiry_month: card.expiry_month,
+        expiry_year: card.expiry_year
       )
       expect(auth_response.success?).to eq false
       expect(auth_response.expired_card?).to eq true
@@ -113,7 +117,9 @@ describe "directly tokenizing card data" do
         amount: 10000,
         payment_account_id: payment_account_id,
         customer_id: "doesntmatter",
-        order_id: "orderblah"
+        order_id: "orderblah",
+        expiry_month: card.expiry_month,
+        expiry_year: card.expiry_year
       )
       expect(auth_response.success?).to eq false
       expect(auth_response.invalid_account_number?).to eq true

--- a/spec/e_protect_spec.rb
+++ b/spec/e_protect_spec.rb
@@ -41,7 +41,9 @@ describe "promoting a temporary token to a permanent token" do
         amount: 10000,
         payment_account_id: payment_account_id,
         customer_id: "doesntmatter",
-        order_id: "orderblah"
+        order_id: "orderblah",
+        expiry_month: '01',
+        expiry_year: '16'
       )
       expect(auth_response.success?).to eq true
     end
@@ -99,7 +101,9 @@ describe "promoting a temporary token to a permanent token" do
         amount: 10000,
         payment_account_id: payment_account_id,
         customer_id: "doesntmatter",
-        order_id: "orderblah"
+        order_id: "orderblah",
+        expiry_month: '01',
+        expiry_year: '16'
       )
       expect(auth_response.success?).to eq false
       expect(auth_response.invalid_account_number?).to eq true

--- a/spec/mocked_sandbox/auth_capture_spec.rb
+++ b/spec/mocked_sandbox/auth_capture_spec.rb
@@ -22,7 +22,9 @@ describe "mocked API requests to auth_capture" do
       amount: amount,
       payment_account_id: payment_account_id,
       customer_id: customer_id,
-      order_id: order_id
+      order_id: order_id,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year
     )
     Vantiv::MockedSandbox.disable_self_mocked_requests!
     response
@@ -34,7 +36,9 @@ describe "mocked API requests to auth_capture" do
       amount: amount,
       payment_account_id: live_sandbox_payment_account_id,
       customer_id: customer_id,
-      order_id: order_id
+      order_id: order_id,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year
     )
   end
 

--- a/spec/mocked_sandbox/auth_reversal_spec.rb
+++ b/spec/mocked_sandbox/auth_reversal_spec.rb
@@ -24,7 +24,9 @@ describe "mocked API requests to auth_reversal" do
       amount: amount,
       payment_account_id: live_sandbox_payment_account_id,
       customer_id: customer_id,
-      order_id: order_id
+      order_id: order_id,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year
     ).transaction_id
   end
 

--- a/spec/mocked_sandbox/auth_spec.rb
+++ b/spec/mocked_sandbox/auth_spec.rb
@@ -22,7 +22,9 @@ describe "mocked API requests to auth" do
       amount: amount,
       payment_account_id: payment_account_id,
       customer_id: customer_id,
-      order_id: order_id
+      order_id: order_id,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year
     )
     Vantiv::MockedSandbox.disable_self_mocked_requests!
     response
@@ -34,7 +36,9 @@ describe "mocked API requests to auth" do
       amount: amount,
       payment_account_id: live_sandbox_payment_account_id,
       customer_id: customer_id,
-      order_id: order_id
+      order_id: order_id,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year
     )
   end
 

--- a/spec/mocked_sandbox/capture_spec.rb
+++ b/spec/mocked_sandbox/capture_spec.rb
@@ -24,7 +24,9 @@ describe "mocked API requests to capture" do
       amount: amount,
       payment_account_id: live_sandbox_payment_account_id,
       customer_id: customer_id,
-      order_id: order_id
+      order_id: order_id,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year
     ).transaction_id
   end
 

--- a/spec/mocked_sandbox/credit_spec.rb
+++ b/spec/mocked_sandbox/credit_spec.rb
@@ -25,7 +25,9 @@ describe "mocked API requests to credit" do
       amount: amount,
       payment_account_id: live_sandbox_payment_account_id,
       customer_id: customer_id,
-      order_id: order_id
+      order_id: order_id,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year
     ).transaction_id
   end
 

--- a/spec/mocked_sandbox/refund_spec.rb
+++ b/spec/mocked_sandbox/refund_spec.rb
@@ -21,7 +21,9 @@ describe "mocked API requests to refund" do
       amount: amount,
       customer_id: customer_id,
       order_id: order_id,
-      payment_account_id: card.mocked_sandbox_payment_account_id
+      payment_account_id: card.mocked_sandbox_payment_account_id,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year
     )
     Vantiv::MockedSandbox.disable_self_mocked_requests!
     response
@@ -33,7 +35,9 @@ describe "mocked API requests to refund" do
       amount: amount,
       customer_id: customer_id,
       order_id: order_id,
-      payment_account_id: live_sandbox_payment_account_id
+      payment_account_id: live_sandbox_payment_account_id,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year
     )
   end
 

--- a/spec/mocked_sandbox/void_spec.rb
+++ b/spec/mocked_sandbox/void_spec.rb
@@ -24,7 +24,9 @@ describe "mocked API requests to void" do
       amount: amount,
       payment_account_id: live_sandbox_payment_account_id,
       customer_id: customer_id,
-      order_id: order_id
+      order_id: order_id,
+      expiry_month: card.expiry_month,
+      expiry_year: card.expiry_year
     ).transaction_id
   end
 

--- a/spec/refund_spec.rb
+++ b/spec/refund_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe "processing standalone refunds" do
-  let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+  let(:test_account) { Vantiv::TestAccount.valid_account }
+  let(:payment_account_id) { test_account.payment_account_id }
   let(:order_id) { "order-#{rand(10000)}" }
 
   def run_refund
@@ -9,7 +10,9 @@ describe "processing standalone refunds" do
       amount: 10000,
       customer_id: "cust-id-123",
       order_id: order_id,
-      payment_account_id: payment_account_id
+      payment_account_id: payment_account_id,
+      expiry_month: test_account.expiry_month,
+      expiry_year: test_account.expiry_year
     )
   end
 

--- a/spec/void_spec.rb
+++ b/spec/void_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe "processing voids" do
-  let(:payment_account_id) { Vantiv::TestAccount.valid_account.payment_account_id }
+  let(:test_account) { Vantiv::TestAccount.valid_account }
+  let(:payment_account_id) { test_account.payment_account_id }
   let(:customer_id) { "customer-#{rand(10000)}" }
   let(:order_id) { "order-#{rand(10000)}" }
 
@@ -15,7 +16,9 @@ describe "processing voids" do
         amount: 81800,
         customer_id: customer_id,
         order_id: order_id,
-        payment_account_id: payment_account_id
+        payment_account_id: payment_account_id,
+        expiry_month: test_account.expiry_month,
+        expiry_year: test_account.expiry_year
       )
       Vantiv.capture(transaction_id: auth.transaction_id)
     end
@@ -42,7 +45,9 @@ describe "processing voids" do
         amount: 81800,
         customer_id: customer_id,
         order_id: order_id,
-        payment_account_id: payment_account_id
+        payment_account_id: payment_account_id,
+        expiry_month: test_account.expiry_month,
+        expiry_year: test_account.expiry_year
       )
       Vantiv.credit(transaction_id: sale.transaction_id, amount: 5)
     end
@@ -69,7 +74,9 @@ describe "processing voids" do
         amount: 81800,
         customer_id: customer_id,
         order_id: order_id,
-        payment_account_id: payment_account_id
+        payment_account_id: payment_account_id,
+        expiry_month: test_account.expiry_month,
+        expiry_year: test_account.expiry_year
       )
     end
 
@@ -95,7 +102,9 @@ describe "processing voids" do
         amount: 81800,
         customer_id: customer_id,
         order_id: order_id,
-        payment_account_id: payment_account_id
+        payment_account_id: payment_account_id,
+        expiry_month: test_account.expiry_month,
+        expiry_year: test_account.expiry_year
       )
     end
 


### PR DESCRIPTION
* Miscommunication during development occurred on whether the expiration
  data was necessary to send during live txns, like auths,
  auth_captures, and refunds that are not tied to prior txns.
* Vantiv now clarified that expiration data is required for card not
  present transactions
* In actuality, the majority of issuing banks or card networks approve
  card not present transactions without the expiration data - Vantiv is
  not requiring this data in their API on the front end, they just
  attempt to place the authorizations, and allow the banks to return a
  Do Not Honor response code