### PR TITLE
make certification script's interface more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Vantiv's DevHub requires merchants to certify their applications for usage with 
 To certify your application, run the following script:
 
 ```
-$ vantiv-certify-app -l sub-your-license-id-in-here -a sub-your-acceptor-id-in-here -p your-paypage-id 
+$ bundle exec vantiv-certify-app -l sub-your-license-id-in-here -a sub-your-acceptor-id-in-here -p your-paypage-id 
 ```
 
 A certs.txt file will be generated in the directory that the script is run, and then opened. It contains a list of DevHub Certification test names and associated Request IDs, like follows:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Vantiv's DevHub requires merchants to certify their applications for usage with 
 To certify your application, run the following script:
 
 ```
-$ LICENSE_ID=sub-your-license-id-in-here ACCEPTOR_ID=sub-your-acceptor-id-in-here PAYPAGE_ID=your-paypage-id vantiv-certify-app
+$ vantiv-certify-app -l sub-your-license-id-in-here -a sub-your-acceptor-id-in-here -p your-paypage-id 
 ```
 
 A certs.txt file will be generated in the directory that the script is run, and then opened. It contains a list of DevHub Certification test names and associated Request IDs, like follows:

--- a/exe/vantiv-certify-app
+++ b/exe/vantiv-certify-app
@@ -5,7 +5,7 @@ require 'vantiv/certification/validation_test_runner'
 require 'optparse'
 
 options = {}
-OptionParser.new do |opts|
+parser = OptionParser.new do |opts|
   opts.banner = "Usage: vantiv-certify-app -a <acceptor_id> -l <license_id> -p <paypage_id> [--filter_by <test_name>]"
 
   opts.on("-a", "--acceptor_id ACCEPTOR_ID", "Vantiv Acceptor ID") do |acceptor_id|
@@ -23,11 +23,17 @@ OptionParser.new do |opts|
   opts.on("--filter_by [TEST_NAME]", "Filter which certifications to run") do |filter|
     options[:filter_by] = filter
   end
-end.parse!
+end
+
+parser.parse!
 
 required_arguments = %i[acceptor_id license_id paypage_id]
-required_arguments.each do |required_argument|
-  raise OptionParser::MissingArgument if options[required_argument].nil?
+missing_arguments = required_arguments.select{ |required_argument| options[required_argument].nil? }
+
+if missing_arguments.any?
+  puts "Missing options: #{missing_arguments.join(", ")}"
+  puts parser.banner
+  exit
 end
 
 Vantiv.configure do |config|

--- a/exe/vantiv-certify-app
+++ b/exe/vantiv-certify-app
@@ -2,22 +2,45 @@
 
 require 'vantiv'
 require 'vantiv/certification/validation_test_runner'
+require 'optparse'
 
-unless ENV['ACCEPTOR_ID'] && ENV['LICENSE_ID'] && ENV['PAYPAGE_ID']
-  raise "Vantiv License ID, Acceptor ID, Paypage ID and Application ID required"
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: vantiv-certify-app -a <acceptor_id> -l <license_id> -p <paypage_id> [--filter_by <test_name>]"
+
+  opts.on("-a", "--acceptor_id ACCEPTOR_ID", "Vantiv Acceptor ID") do |acceptor_id|
+    options[:acceptor_id] = acceptor_id
+  end
+
+  opts.on("-l", "--license_id LICENSE_ID", "Vantiv License ID") do |license_id|
+    options[:license_id] = license_id
+  end
+
+  opts.on("-p", "--paypage_id PAYPAGE_ID", "Vantiv Paypage ID") do |paypage_id|
+    options[:paypage_id] = paypage_id
+  end
+
+  opts.on("--filter_by [TEST_NAME]", "Filter which certifications to run") do |filter|
+    options[:filter_by] = filter
+  end
+end.parse!
+
+required_arguments = %i[acceptor_id license_id paypage_id]
+required_arguments.each do |required_argument|
+  raise OptionParser::MissingArgument if options[required_argument].nil?
 end
 
 Vantiv.configure do |config|
-  config.license_id = ENV["LICENSE_ID"]
-  config.acceptor_id = ENV["ACCEPTOR_ID"]
-  config.paypage_id = ENV["PAYPAGE_ID"]
+  config.license_id = options.fetch(:license_id)
+  config.acceptor_id = options.fetch(:acceptor_id)
+  config.paypage_id = options.fetch(:paypage_id)
   config.environment = Vantiv::Environment::CERTIFICATION
 
   config.default_report_group = '1'
 end
 
 Vantiv::Certification::ValidationTestRunner.run(
-  filter_by: ENV["FILTER_BY"],
+  filter_by: options[:filter_by],
   save_to: "certs.txt"
 )
 


### PR DESCRIPTION
Also adds nifty usage information:

![image](https://cloud.githubusercontent.com/assets/1071954/15329371/7fd98e66-1c26-11e6-8766-43fd7301306d.png)
