### PR TITLE
Refactor RequestBody

### DIFF
--- a/lib/vantiv/api/request_body.rb
+++ b/lib/vantiv/api/request_body.rb
@@ -53,7 +53,11 @@ module Vantiv
 
       def self.for_tokenization(paypage_registration_id:)
         RequestBodyGenerator.run(
-          card_element_for_tokenization(paypage_registration_id)
+          {
+            "Card" => {
+              "PaypageRegistrationID" => paypage_registration_id
+            }
+          }
         )
       end
 
@@ -72,14 +76,6 @@ module Vantiv
 
       def self.for_void(transaction_id:)
         RequestBodyGenerator.run(tied_transaction_element(transaction_id: transaction_id))
-      end
-
-      def self.card_element_for_tokenization(paypage_registration_id)
-        {
-          "Card" => {
-            "PaypageRegistrationID" => paypage_registration_id
-          }
-        }
       end
 
       def self.card_element_for_live_transactions(expiry_month:, expiry_year:)


### PR DESCRIPTION
removes an unnecessary abstraction - `.card_element_for_tokenization` was only being used in one place and isn't doing anything too complex so I think it is easier to follow if we pull it out of the method.