### PR TITLE
Isolate logic for turning objects into json

### DIFF
--- a/lib/vantiv/api/request.rb
+++ b/lib/vantiv/api/request.rb
@@ -4,7 +4,7 @@ module Vantiv
 
     def initialize(endpoint:, body:, response_object:)
       @endpoint = endpoint
-      @body = body.to_json
+      @body = body
       @response_object = response_object
       @retry_count = 0
     end
@@ -18,7 +18,7 @@ module Vantiv
       http.use_ssl = true
 
       request = Net::HTTP::Post.new(uri.request_uri, header)
-      request.body = body
+      request.body = body.to_json
 
       http_response = http.request(request)
 

--- a/lib/vantiv/api/request.rb
+++ b/lib/vantiv/api/request.rb
@@ -14,18 +14,40 @@ module Vantiv
     end
 
     def run_request
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-
-      request = Net::HTTP::Post.new(uri.request_uri, header)
-      request.body = body.to_json
-
-      http_response = http.request(request)
+      http_response = make_json_request
 
       populated_response(@response_object, http_response)
     end
 
     private
+
+    def make_json_request
+      http = Net::HTTP.new(json_uri.host, json_uri.port)
+      http.use_ssl = true
+      json_request = Net::HTTP::Post.new(json_uri.request_uri, json_header)
+      json_request.body = body.to_json
+
+      http.request(json_request)
+    end
+
+    def json_header
+      {
+        "Content-Type" =>"application/json",
+        "Authorization" => "VANTIV license=\"#{Vantiv.license_id}\""
+      }
+    end
+
+    def json_uri
+      @uri ||= URI.parse("#{json_root_uri}/#{@endpoint}")
+    end
+
+    def json_root_uri
+      if Vantiv::Environment.production?
+        "https://apis.vantiv.com"
+      elsif Vantiv::Environment.certification?
+        "https://apis.cert.vantiv.com"
+      end
+    end
 
     def populated_response(response, http_response)
       new_response = response.dup
@@ -40,25 +62,6 @@ module Vantiv
       new_response.body = response_body
 
       new_response
-    end
-
-    def header
-      {
-        "Content-Type" =>"application/json",
-        "Authorization" => "VANTIV license=\"#{Vantiv.license_id}\""
-      }
-    end
-
-    def uri
-      @uri ||= URI.parse("#{root_uri}/#{@endpoint}")
-    end
-
-    def root_uri
-      if Vantiv::Environment.production?
-        "https://apis.vantiv.com"
-      elsif Vantiv::Environment.certification?
-        "https://apis.cert.vantiv.com"
-      end
     end
 
     def increment_retry_count

--- a/lib/vantiv/api/request_body.rb
+++ b/lib/vantiv/api/request_body.rb
@@ -17,7 +17,11 @@ module Vantiv
       end
 
       def to_hash
-        ::RequestBodyRepresenter.new(self).to_hash
+        self
+      end
+
+      def to_json
+        ::RequestBodyRepresenter.new(self).to_json
       end
 
       def self.for_auth_or_sale(amount:, customer_id:, order_id:, payment_account_id:, expiry_month:, expiry_year:)

--- a/lib/vantiv/api/request_body.rb
+++ b/lib/vantiv/api/request_body.rb
@@ -16,10 +16,6 @@ module Vantiv
         @report_group = Vantiv.default_report_group
       end
 
-      def to_hash
-        self
-      end
-
       def to_json
         ::RequestBodyRepresenter.new(self).to_json
       end
@@ -42,22 +38,22 @@ module Vantiv
           transaction: transaction,
           card: card,
           payment_account: payment_account
-        ).to_hash
+        )
       end
 
       def self.for_auth_reversal(transaction_id:, amount: nil)
         transaction = Transaction.new(id: transaction_id, amount_in_cents: amount)
-        new(transaction: transaction).to_hash
+        new(transaction: transaction)
       end
 
       def self.for_capture(transaction_id:, amount: nil)
         transaction = Transaction.new(id: transaction_id, amount_in_cents: amount)
-        new(transaction: transaction).to_hash
+        new(transaction: transaction)
       end
 
       def self.for_credit(transaction_id:, amount: nil)
         transaction = Transaction.new(id: transaction_id, amount_in_cents: amount)
-        new(transaction: transaction).to_hash
+        new(transaction: transaction)
       end
 
       def self.for_return(amount:, customer_id:, order_id:, payment_account_id:, expiry_month:, expiry_year:)
@@ -77,12 +73,12 @@ module Vantiv
           transaction: transaction,
           card: card,
           payment_account: payment_account
-        ).to_hash
+        )
       end
 
       def self.for_tokenization(paypage_registration_id:)
         card = Card.new(paypage_registration_id: paypage_registration_id)
-        new(card: card).to_hash
+        new(card: card)
       end
 
       def self.for_direct_post_tokenization(card_number:, expiry_month:, expiry_year:, cvv:)
@@ -92,12 +88,12 @@ module Vantiv
           expiry_year: expiry_year,
           cvv: cvv
         )
-        new(card: card).to_hash
+        new(card: card)
       end
 
       def self.for_void(transaction_id:)
         transaction = Transaction.new(id: transaction_id)
-        new(transaction: transaction).to_hash
+        new(transaction: transaction)
       end
 
     end

--- a/lib/vantiv/api/request_body_representer.rb
+++ b/lib/vantiv/api/request_body_representer.rb
@@ -21,10 +21,10 @@ class RequestBodyRepresenter < Representable::Decorator
 
   property :transaction, as: :Transaction, class: Vantiv::Api::Transaction do
     property :id, as: :TransactionID
-    property :amount, as: :TransactionAmount
     property :order_id, as: :ReferenceNumber
-    property :customer_id, as: :CustomerID
+    property :amount, as: :TransactionAmount
     property :order_source, as: :OrderSource
+    property :customer_id, as: :CustomerID
     property :partial_approved_flag, as: :PartialApprovedFlag
   end
 

--- a/lib/vantiv/mocked_sandbox/api_request.rb
+++ b/lib/vantiv/mocked_sandbox/api_request.rb
@@ -49,20 +49,20 @@ module Vantiv
       attr_accessor :endpoint, :request_body, :fixture, :response_object
 
       def direct_post?
-        request_body["Card"] && request_body["Card"]["AccountNumber"] != nil
+        !card_number.nil?
       end
 
       def temporary_token
-        request_body["Card"]["PaypageRegistrationID"]
+        request_body.card.paypage_registration_id
       end
 
       def card_number
-        request_body["Card"]["AccountNumber"]
+        request_body.card.account_number
       end
 
       def card_number_from_payment_account_id
         TestCard.find_by_payment_account_id(
-          request_body["PaymentAccount"]["PaymentAccountID"]
+          request_body.payment_account.id
         ).card_number
       end
 

--- a/lib/vantiv/mocked_sandbox/api_request.rb
+++ b/lib/vantiv/mocked_sandbox/api_request.rb
@@ -14,7 +14,7 @@ module Vantiv
 
       def initialize(endpoint, request_body, response_object)
         self.endpoint = endpoint
-        self.request_body = JSON.parse(request_body)
+        self.request_body = request_body
         self.response_object = response_object
       end
 

--- a/spec/api/request_body_spec.rb
+++ b/spec/api/request_body_spec.rb
@@ -16,29 +16,29 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
-    it "returns the expected body" do
+    it "returns the expected json" do
       allow(SecureRandom).to receive(:hex).and_return "the-application-id"
       expected = {"Credentials"=>{"AcceptorID"=>"1166386"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Card"=>{"AccountNumber"=>"1234", "ExpirationMonth"=>"10", "ExpirationYear"=>"18", "CVV"=>"222"}}
-      expect(request_body).to eq(expected)
+      expect(request_body.to_json).to eq expected.to_json
     end
 
-    it "includes the AcceptorID" do
-      expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+    it "includes the acceptor id" do
+      expect(request_body.acceptor_id).to eq "1166386"
     end
 
-    it "includes the default ReportGroup" do
-      expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+    it "includes the default report group" do
+      expect(request_body.report_group).to eq "1"
     end
 
-    it "include the ApplicationID" do
-      expect(request_body["Application"]["ApplicationID"]).to be
+    it "include the application id" do
+      expect(request_body.application_id).to be
     end
 
     it "includes stringified versions of card params" do
-      expect(request_body["Card"]["AccountNumber"]).to eq(card_number.to_s)
-      expect(request_body["Card"]["ExpirationMonth"]).to eq("10")
-      expect(request_body["Card"]["ExpirationYear"]).to eq("18")
-      expect(request_body["Card"]["CVV"]).to eq(cvv.to_s)
+      expect(request_body.card.account_number).to eq card_number.to_s
+      expect(request_body.card.expiry_month).to eq "10"
+      expect(request_body.card.expiry_year).to eq "18"
+      expect(request_body.card.cvv).to eq cvv.to_s
     end
   end
 
@@ -53,26 +53,26 @@ describe Vantiv::Api::RequestBody do
       @paypage_registration_id = "some-temp-token"
     end
 
-    it "returns the expected body" do
+    it "returns the expected json" do
       allow(SecureRandom).to receive(:hex).and_return "the-application-id"
       expected = {"Credentials"=>{"AcceptorID"=>"1166386"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Card"=>{"PaypageRegistrationID"=>"some-temp-token"}}
-      expect(request_body).to eq(expected)
+      expect(request_body.to_json).to eq expected.to_json
     end
 
-    it "includes the AcceptorID" do
-      expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+    it "includes the acceptor id" do
+      expect(request_body.acceptor_id).to eq "1166386"
     end
 
-    it "includes the default ReportGroup" do
-      expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+    it "includes the default report group" do
+      expect(request_body.report_group).to eq "1"
     end
 
-    it "include the ApplicationID" do
-      expect(request_body["Application"]["ApplicationID"]).to be
+    it "include the application id" do
+      expect(request_body.application_id).to be
     end
 
-    it "includes the paypage registration ID correctly" do
-      expect(request_body["Card"]["PaypageRegistrationID"]).to eq "some-temp-token"
+    it "includes the paypage registration id" do
+      expect(request_body.card.paypage_registration_id).to eq "some-temp-token"
     end
   end
 
@@ -84,10 +84,10 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
-    it "returns the expected body" do
+    it "returns the expected json" do
       allow(SecureRandom).to receive(:hex).and_return "the-application-id"
       expected = {"Credentials"=>{"AcceptorID"=>"1166386"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Transaction"=>{"TransactionID"=>"transactionid123"}}
-      expect(request_body).to eq(expected)
+      expect(request_body.to_json).to eq expected.to_json
     end
 
     context "when amount is nil" do
@@ -95,24 +95,24 @@ describe Vantiv::Api::RequestBody do
         @amount = nil
       end
 
-      it "includes the AcceptorID" do
-        expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+      it "includes the acceptor id" do
+        expect(request_body.acceptor_id).to eq "1166386"
       end
 
-      it "includes the default ReportGroup" do
-        expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+      it "includes the default report group" do
+        expect(request_body.report_group).to eq "1"
       end
 
-      it "include the ApplicationID" do
-        expect(request_body["Application"]["ApplicationID"]).to be
+      it "include the application id" do
+        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
-        expect(request_body["Transaction"]["TransactionID"]).to eq("transactionid123")
+        expect(request_body.transaction.id).to eq "transactionid123"
       end
 
-      it "does not include the TransactionAmount" do
-        expect(request_body["Transaction"]["TransactionAmount"]).to be_nil
+      it "does not include the transaction amount" do
+        expect(request_body.transaction.amount).to be_nil
       end
     end
 
@@ -121,24 +121,24 @@ describe Vantiv::Api::RequestBody do
         @amount = 58888
       end
 
-      it "includes the AcceptorID" do
-        expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+      it "includes the acceptor id" do
+        expect(request_body.acceptor_id).to eq "1166386"
       end
 
-      it "includes the default ReportGroup" do
-        expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+      it "includes the default report group" do
+        expect(request_body.report_group).to eq "1"
       end
 
-      it "include the ApplicationID" do
-        expect(request_body["Application"]["ApplicationID"]).to be
+      it "include the application id" do
+        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
-        expect(request_body["Transaction"]["TransactionID"]).to eq("transactionid123")
+        expect(request_body.transaction.id).to eq "transactionid123"
       end
 
-      it "includes the TransactionAmount" do
-        expect(request_body["Transaction"]["TransactionAmount"]).to eq("588.88")
+      it "includes the transaction amount" do
+        expect(request_body.transaction.amount).to eq "588.88"
       end
     end
   end
@@ -155,66 +155,66 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
-    it "returns the expected body" do
+    it "returns the expected json" do
       allow(SecureRandom).to receive(:hex).and_return "the-application-id"
       expected = {"Credentials"=>{"AcceptorID"=>"1166386"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Transaction"=>{"ReferenceNumber"=>"SomeOrder123", "TransactionAmount"=>"42.24", "OrderSource"=>"ecommerce", "CustomerID"=>"extid123", "PartialApprovedFlag"=>false}, "Card"=>{"ExpirationMonth"=>"08", "ExpirationYear"=>"18"}, "PaymentAccount"=>{"PaymentAccountID"=>"paymentacct123"}}
-      expect(request_body).to eq(expected)
+      expect(request_body.to_json).to eq expected.to_json
     end
 
-    it "includes the AcceptorID" do
-      expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+    it "includes the acceptor id" do
+      expect(request_body.acceptor_id).to eq "1166386"
     end
 
-    it "includes the default ReportGroup" do
-      expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+    it "includes the default report group" do
+      expect(request_body.report_group).to eq "1"
     end
 
-    it "include the ApplicationID" do
-      expect(request_body["Application"]["ApplicationID"]).to be
+    it "include the application id" do
+      expect(request_body.application_id).to be
     end
 
     context "Transaction object" do
       it "is included" do
-        expect(request_body["Transaction"]).not_to eq nil
+        expect(request_body.transaction).to be
       end
 
-      it "includes the ReferenceNumber" do
-        expect(request_body["Transaction"]["ReferenceNumber"]).to eq "SomeOrder123"
+      it "includes the order id" do
+        expect(request_body.transaction.order_id).to eq "SomeOrder123"
       end
 
-      it "includes the TransactionAmount" do
-        expect(request_body["Transaction"]["TransactionAmount"]).to eq "42.24"
+      it "includes the transaction amount" do
+        expect(request_body.transaction.amount).to eq "42.24"
       end
 
-      it "includes the OrderSource" do
-        expect(request_body["Transaction"]["OrderSource"]).to eq "ecommerce"
+      it "includes the order source" do
+        expect(request_body.transaction.order_source).to eq "ecommerce"
       end
 
-      it "includes the CustomerID" do
-        expect(request_body["Transaction"]["CustomerID"]).to eq "extid123"
+      it "includes the customer id" do
+        expect(request_body.transaction.customer_id).to eq "extid123"
       end
 
-      it "includes the PartialApprovedFlag" do
-        expect(request_body["Transaction"]["PartialApprovedFlag"]).to eq false
+      it "includes the partial approved flag" do
+        expect(request_body.transaction.partial_approved_flag).to eq false
       end
     end
 
     context "Card object" do
       it "is included" do
-        expect(request_body["Card"]).not_to eq nil
+        expect(request_body.card).to be
       end
 
-      it "includes ExpirationMonth" do
-        expect(request_body["Card"]["ExpirationMonth"]).to eq "08"
+      it "includes expiry month" do
+        expect(request_body.card.expiry_month).to eq "08"
       end
 
-      it "includes ExpirationYear" do
-        expect(request_body["Card"]["ExpirationYear"]).to eq "18"
+      it "includes expiry year" do
+        expect(request_body.card.expiry_year).to eq "18"
       end
     end
 
-    it "includes the PaymentAccountID" do
-      expect(request_body["PaymentAccount"]["PaymentAccountID"]).to eq "paymentacct123"
+    it "includes the payment account id" do
+      expect(request_body.payment_account.id).to eq "paymentacct123"
     end
 
     it "casts order id to string" do
@@ -226,7 +226,7 @@ describe Vantiv::Api::RequestBody do
         expiry_month: "12",
         expiry_year: "2099"
       )
-      expect(body["Transaction"]["ReferenceNumber"]).to eq "123"
+      expect(body.transaction.order_id).to eq "123"
     end
 
   end
@@ -244,30 +244,30 @@ describe Vantiv::Api::RequestBody do
         @amount = nil
       end
 
-      it "returns the expected body" do
+      it "returns the expected json" do
         allow(SecureRandom).to receive(:hex).and_return "the-application-id"
         expected = {"Credentials"=>{"AcceptorID"=>"1166386"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Transaction"=>{"TransactionID"=>"transactionid123"}}
-        expect(request_body).to eq(expected)
+        expect(request_body.to_json).to eq expected.to_json
       end
 
-      it "includes the AcceptorID" do
-        expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+      it "includes the acceptor id" do
+        expect(request_body.acceptor_id).to eq "1166386"
       end
 
-      it "includes the default ReportGroup" do
-        expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+      it "includes the default report group" do
+        expect(request_body.report_group).to eq "1"
       end
 
-      it "include the ApplicationID" do
-        expect(request_body["Application"]["ApplicationID"]).to be
+      it "include the application id" do
+        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
-        expect(request_body["Transaction"]["TransactionID"]).to eq("transactionid123")
+        expect(request_body.transaction.id).to eq "transactionid123"
       end
 
-      it "does not include the TransactionAmount" do
-        expect(request_body["Transaction"]["TransactionAmount"]).to be_nil
+      it "does not include the transaction amount" do
+        expect(request_body.transaction.amount).to be_nil
       end
     end
 
@@ -276,30 +276,30 @@ describe Vantiv::Api::RequestBody do
         @amount = 58888
       end
 
-      it "returns the expected body" do
+      it "returns the expected json" do
         allow(SecureRandom).to receive(:hex).and_return "the-application-id"
         expected = {"Credentials"=>{"AcceptorID"=>"1166386"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Transaction"=>{"TransactionID"=>"transactionid123", "TransactionAmount"=>"588.88"}}
-        expect(request_body).to eq(expected)
+        expect(request_body.to_json).to eq expected.to_json
       end
 
-      it "includes the AcceptorID" do
-        expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+      it "includes the acceptor id" do
+        expect(request_body.acceptor_id).to eq "1166386"
       end
 
-      it "includes the default ReportGroup" do
-        expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+      it "includes the default report group" do
+        expect(request_body.report_group).to eq "1"
       end
 
-      it "include the ApplicationID" do
-        expect(request_body["Application"]["ApplicationID"]).to be
+      it "include the application id" do
+        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
-        expect(request_body["Transaction"]["TransactionID"]).to eq("transactionid123")
+        expect(request_body.transaction.id).to eq "transactionid123"
       end
 
-      it "includes the TransactionAmount" do
-        expect(request_body["Transaction"]["TransactionAmount"]).to eq("588.88")
+      it "includes the transaction amount" do
+        expect(request_body.transaction.amount).to eq "588.88"
       end
     end
   end
@@ -317,30 +317,30 @@ describe Vantiv::Api::RequestBody do
         @amount = nil
       end
 
-      it "returns the expected body" do
+      it "returns the expected json" do
         allow(SecureRandom).to receive(:hex).and_return "the-application-id"
         expected = {"Credentials"=>{"AcceptorID"=>"1166386"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Transaction"=>{"TransactionID"=>"transactionid123"}}
-        expect(request_body).to eq(expected)
+        expect(request_body.to_json).to eq expected.to_json
       end
 
-      it "includes the AcceptorID" do
-        expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+      it "includes the acceptor id" do
+        expect(request_body.acceptor_id).to eq "1166386"
       end
 
-      it "includes the default ReportGroup" do
-        expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+      it "includes the default report group" do
+        expect(request_body.report_group).to eq "1"
       end
 
-      it "include the ApplicationID" do
-        expect(request_body["Application"]["ApplicationID"]).to be
+      it "include the application id" do
+        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
-        expect(request_body["Transaction"]["TransactionID"]).to eq("transactionid123")
+        expect(request_body.transaction.id).to eq "transactionid123"
       end
 
-      it "does not include the TransactionAmount" do
-        expect(request_body["Transaction"]["TransactionAmount"]).to be_nil
+      it "does not include the transaction amount" do
+        expect(request_body.transaction.amount).to be_nil
       end
     end
 
@@ -349,30 +349,30 @@ describe Vantiv::Api::RequestBody do
         @amount = 58888
       end
 
-      it "returns the expected body" do
+      it "returns the expected json" do
         allow(SecureRandom).to receive(:hex).and_return "the-application-id"
         expected = {"Credentials"=>{"AcceptorID"=>"1166386"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Transaction"=>{"TransactionID"=>"transactionid123", "TransactionAmount"=>"588.88"}}
-        expect(request_body).to eq(expected)
+        expect(request_body.to_json).to eq expected.to_json
       end
 
-      it "includes the AcceptorID" do
-        expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+      it "includes the acceptor id" do
+        expect(request_body.acceptor_id).to eq "1166386"
       end
 
-      it "includes the default ReportGroup" do
-        expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+      it "includes the default report group" do
+        expect(request_body.report_group).to eq "1"
       end
 
-      it "include the ApplicationID" do
-        expect(request_body["Application"]["ApplicationID"]).to be
+      it "include the application id" do
+        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
-        expect(request_body["Transaction"]["TransactionID"]).to eq("transactionid123")
+        expect(request_body.transaction.id).to eq "transactionid123"
       end
 
-      it "includes the TransactionAmount" do
-        expect(request_body["Transaction"]["TransactionAmount"]).to eq("588.88")
+      it "includes the transaction amount" do
+        expect(request_body.transaction.amount).to eq "588.88"
       end
     end
   end
@@ -389,66 +389,66 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
-    it "returns the expected body" do
+    it "returns the expected json" do
       allow(SecureRandom).to receive(:hex).and_return "the-application-id"
       expected = {"Credentials"=>{"AcceptorID"=>"1166386"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Transaction"=>{"ReferenceNumber"=>"SomeOrder123", "TransactionAmount"=>"42.24", "OrderSource"=>"ecommerce", "CustomerID"=>"extid123"}, "Card"=>{"ExpirationMonth"=>"08", "ExpirationYear"=>"18"}, "PaymentAccount"=>{"PaymentAccountID"=>"paymentacct123"}}
-      expect(request_body).to eq(expected)
+      expect(request_body.to_json).to eq expected.to_json
     end
 
-    it "includes the AcceptorID" do
-      expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+    it "includes the acceptor id" do
+      expect(request_body.acceptor_id).to eq "1166386"
     end
 
-    it "includes the default ReportGroup" do
-      expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+    it "includes the default report group" do
+      expect(request_body.report_group).to eq "1"
     end
 
-    it "include the ApplicationID" do
-      expect(request_body["Application"]["ApplicationID"]).to be
+    it "include the application id" do
+      expect(request_body.application_id).to be
     end
 
     context "Transaction object" do
       it "is included" do
-        expect(request_body["Transaction"]).not_to eq nil
+        expect(request_body.transaction).to be
       end
 
-      it "includes the ReferenceNumber" do
-        expect(request_body["Transaction"]["ReferenceNumber"]).to eq "SomeOrder123"
+      it "includes the order id" do
+        expect(request_body.transaction.order_id).to eq "SomeOrder123"
       end
 
-      it "includes the TransactionAmount" do
-        expect(request_body["Transaction"]["TransactionAmount"]).to eq "42.24"
+      it "includes the amount" do
+        expect(request_body.transaction.amount).to eq "42.24"
       end
 
-      it "includes the OrderSource" do
-        expect(request_body["Transaction"]["OrderSource"]).to eq "ecommerce"
+      it "includes the order source" do
+        expect(request_body.transaction.order_source).to eq "ecommerce"
       end
 
-      it "includes the CustomerID" do
-        expect(request_body["Transaction"]["CustomerID"]).to eq "extid123"
+      it "includes the customer id" do
+        expect(request_body.transaction.customer_id).to eq "extid123"
       end
 
-      it "does not include the PartialApprovedFlag" do
-        expect(request_body["Transaction"]["PartialApprovedFlag"]).to be_nil
+      it "does not include the partial approved flag" do
+        expect(request_body.transaction.partial_approved_flag).to be_nil
       end
     end
 
     context "Card object" do
       it "is included" do
-        expect(request_body["Card"]).not_to eq nil
+        expect(request_body.card).to be
       end
 
-      it "includes ExpirationMonth" do
-        expect(request_body["Card"]["ExpirationMonth"]).to eq "08"
+      it "includes expiry month" do
+        expect(request_body.card.expiry_month).to eq "08"
       end
 
-      it "includes ExpirationYear" do
-        expect(request_body["Card"]["ExpirationYear"]).to eq "18"
+      it "includes expiry year" do
+        expect(request_body.card.expiry_year).to eq "18"
       end
     end
 
     it "includes the PaymentAccountID" do
-      expect(request_body["PaymentAccount"]["PaymentAccountID"]).to eq "paymentacct123"
+      expect(request_body.payment_account.id).to eq "paymentacct123"
     end
   end
 
@@ -459,26 +459,26 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
-    it "returns the expected body" do
+    it "returns the expected json" do
       allow(SecureRandom).to receive(:hex).and_return "the-application-id"
       expected = {"Credentials"=>{"AcceptorID"=>"1166386"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Transaction"=>{"TransactionID"=>"transactionid123"}}
-      expect(request_body).to eq(expected)
+      expect(request_body.to_json).to eq expected.to_json
     end
 
-    it "includes the AcceptorID" do
-      expect(request_body["Credentials"]["AcceptorID"]).to eq("1166386")
+    it "includes the acceptor id" do
+      expect(request_body.acceptor_id).to eq "1166386"
     end
 
-    it "includes the default ReportGroup" do
-      expect(request_body["Reports"]["ReportGroup"]).to eq("1")
+    it "includes the default report group" do
+      expect(request_body.report_group).to eq "1"
     end
 
-    it "include the ApplicationID" do
-      expect(request_body["Application"]["ApplicationID"]).to be
+    it "include the application id" do
+      expect(request_body.application_id).to be
     end
 
     it "includes the transaction id" do
-      expect(request_body["Transaction"]["TransactionID"]).to eq("transactionid123")
+      expect(request_body.transaction.id).to eq "transactionid123"
     end
   end
 

--- a/spec/mocked_sandbox/api_request_spec.rb
+++ b/spec/mocked_sandbox/api_request_spec.rb
@@ -19,7 +19,7 @@ describe Vantiv::MockedSandbox::ApiRequest do
       expiry_month: card.expiry_month,
       expiry_year: card.expiry_year,
       cvv: card.cvv
-    ).to_json
+    )
   end
 
   let(:run_mocked_request) {

--- a/spec/support/test_account.rb
+++ b/spec/support/test_account.rb
@@ -129,7 +129,7 @@ module Vantiv
     def tokenization_request_body
       transaction = Api::Transaction.new(customer_id: "123")
       card = Api::Card.new(expiry_month: expiry_month, expiry_year: expiry_year, account_number: card_number)
-      Api::RequestBody.new(card: card, transaction: transaction).to_hash
+      Api::RequestBody.new(card: card, transaction: transaction)
     end
 
     def request_payment_account_id


### PR DESCRIPTION
This continues the refactor replacing hashes with objects and does the following:
- converts a `RequestBody` directly into JSON rather than into a hash and then into JSON
- moves the conversion of the `RequestBody` to JSON closer to where the actual request is made

The goal of this is to make it easier to switch to the XML API. In future PRs I can imagine adding a `to_xml` to `RequestBody`.