### PR TITLE
allow auth_capture to be configured to use_xml endpoint

### DIFF
--- a/lib/vantiv.rb
+++ b/lib/vantiv.rb
@@ -84,7 +84,7 @@ module Vantiv
     ).run
   end
 
-  def self.auth_capture(amount:, payment_account_id:, customer_id:, order_id:, expiry_month:, expiry_year:)
+  def self.auth_capture(amount:, payment_account_id:, customer_id:, order_id:, expiry_month:, expiry_year:, use_xml: false)
     body = Api::RequestBody.for_auth_or_sale(
       amount: amount,
       order_id: order_id,
@@ -96,7 +96,8 @@ module Vantiv
     Api::Request.new(
       endpoint: Api::Endpoints::SALE,
       body: body,
-      response_object: Api::LiveTransactionResponse.new(:sale)
+      response_object: Api::LiveTransactionResponse.new(:sale),
+      use_xml: use_xml
     ).run
   end
 

--- a/spec/auth_capture_spec.rb
+++ b/spec/auth_capture_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 
 describe "auth_capture (Sale)" do
-  let(:customer_external_id) { "1234" }
-  let(:payment_account_id) { test_account.payment_account_id }
-
   subject(:response) do
     Vantiv.auth_capture(
       amount: 10000,
@@ -11,117 +8,240 @@ describe "auth_capture (Sale)" do
       customer_id: customer_external_id,
       order_id: "SomeOrder123",
       expiry_month: test_account.expiry_month,
-      expiry_year: test_account.expiry_year
+      expiry_year: test_account.expiry_year,
+      use_xml: use_xml
     )
   end
 
-  context "on a valid account" do
-    let(:test_account) { Vantiv::TestAccount.valid_account }
+  context "when use_xml is false" do
+    let(:use_xml) { false }
+    let(:customer_external_id) { "1234" }
+    let(:payment_account_id) { test_account.payment_account_id }
 
-    it "returns success response" do
-      expect(response.success?).to eq true
+    context "on a valid account" do
+      let(:test_account) { Vantiv::TestAccount.valid_account }
+
+      it "returns success response" do
+        expect(response.success?).to eq true
+      end
+
+      it "returns a transaction ID" do
+        expect(response.transaction_id).not_to eq nil
+        expect(response.transaction_id).not_to eq ""
+      end
+
+      it "returns a '000' response code" do
+        expect(response.response_code).to eq('000')
+      end
     end
 
-    it "returns a transaction ID" do
-      expect(response.transaction_id).not_to eq nil
-      expect(response.transaction_id).not_to eq ""
+    context "on an account with insufficient funds" do
+      let(:test_account) { Vantiv::TestAccount.insufficient_funds }
+
+      it "returns a failure response" do
+        expect(response.success?).to eq false
+        expect(response.failure?).to eq true
+      end
+
+      it "returns a transaction ID" do
+        expect(response.transaction_id).not_to eq nil
+        expect(response.transaction_id).not_to eq ""
+      end
+
+      it "gives a human readable reason" do
+        expect(response.message).to match(/insufficient funds/i)
+      end
+
+      it "notifies that it is insufficient funds" do
+        expect(response.insufficient_funds?).to eq true
+      end
+
+      it "returns a '110' response code" do
+        expect(response.response_code).to eq('110')
+      end
     end
 
-    it "returns a '000' response code" do
-      expect(response.response_code).to eq('000')
+    context "on an account with an invalid account number" do
+      let(:test_account) { Vantiv::TestAccount.invalid_account_number }
+
+      it "returns a failure response" do
+        expect(response.success?).to eq false
+        expect(response.failure?).to eq true
+      end
+
+      it "returns a transaction ID" do
+        expect(response.transaction_id).not_to eq nil
+        expect(response.transaction_id).not_to eq ""
+      end
+
+      it "gives a human readable reason" do
+        expect(response.message).to match(/invalid account number/i)
+      end
+
+      it "responds to invalid_account_number?" do
+        expect(response.invalid_account_number?).to eq true
+      end
+
+      it "returns a '301' response code" do
+        expect(response.response_code).to eq('301')
+      end
+    end
+
+    context "on an account with misc errors, like pick up card" do
+      let(:test_account) { Vantiv::TestAccount.pick_up_card }
+
+      it "returns a failure response" do
+        expect(response.success?).to eq false
+        expect(response.failure?).to eq true
+      end
+
+      it "returns a transaction ID" do
+        expect(response.transaction_id).not_to eq nil
+        expect(response.transaction_id).not_to eq ""
+      end
+
+      it "gives a human readable reason" do
+        expect(response.message).not_to eq nil
+        expect(response.message).not_to eq ""
+      end
+
+      it "returns a '303' response code" do
+        expect(response.response_code).to eq('303')
+      end
+    end
+
+    context "when API level failure occurs" do
+      let(:test_account) { Vantiv::TestAccount.valid_account }
+
+      before do
+        @license_id = Vantiv.license_id
+        Vantiv.license_id = "invalid"
+      end
+
+      after do
+        Vantiv.license_id = @license_id
+      end
+
+      it "responds that the authorization failed" do
+        expect(response.failure?).to eq true
+        expect(response.api_level_failure?).to eq true
+      end
     end
   end
 
-  context "on an account with insufficient funds" do
-    let(:test_account) { Vantiv::TestAccount.insufficient_funds }
+  context "when use_xml is false" do
+    let(:use_xml) { true }
+    let(:customer_external_id) { "1234" }
+    let(:payment_account_id) { test_account.payment_account_id }
 
-    it "returns a failure response" do
-      expect(response.success?).to eq false
-      expect(response.failure?).to eq true
+    context "on a valid account" do
+      let(:test_account) { Vantiv::TestAccount.valid_account }
+
+      it "returns success response" do
+        expect(response.success?).to eq true
+      end
+
+      it "returns a transaction ID" do
+        expect(response.transaction_id).not_to eq nil
+        expect(response.transaction_id).not_to eq ""
+      end
+
+      it "returns a '000' response code" do
+        expect(response.response_code).to eq('000')
+      end
     end
 
-    it "returns a transaction ID" do
-      expect(response.transaction_id).not_to eq nil
-      expect(response.transaction_id).not_to eq ""
+    context "on an account with insufficient funds" do
+      let(:test_account) { Vantiv::TestAccount.insufficient_funds }
+
+      it "returns a failure response" do
+        expect(response.success?).to eq false
+        expect(response.failure?).to eq true
+      end
+
+      it "returns a transaction ID" do
+        expect(response.transaction_id).not_to eq nil
+        expect(response.transaction_id).not_to eq ""
+      end
+
+      it "gives a human readable reason" do
+        expect(response.message).to match(/insufficient funds/i)
+      end
+
+      it "notifies that it is insufficient funds" do
+        expect(response.insufficient_funds?).to eq true
+      end
+
+      it "returns a '110' response code" do
+        expect(response.response_code).to eq('110')
+      end
     end
 
-    it "gives a human readable reason" do
-      expect(response.message).to match(/insufficient funds/i)
+    context "on an account with an invalid account number" do
+      let(:test_account) { Vantiv::TestAccount.invalid_account_number }
+
+      it "returns a failure response" do
+        expect(response.success?).to eq false
+        expect(response.failure?).to eq true
+      end
+
+      it "returns a transaction ID" do
+        expect(response.transaction_id).not_to eq nil
+        expect(response.transaction_id).not_to eq ""
+      end
+
+      it "gives a human readable reason" do
+        expect(response.message).to match(/invalid account number/i)
+      end
+
+      it "responds to invalid_account_number?" do
+        expect(response.invalid_account_number?).to eq true
+      end
+
+      it "returns a '301' response code" do
+        expect(response.response_code).to eq('301')
+      end
     end
 
-    it "notifies that it is insufficient funds" do
-      expect(response.insufficient_funds?).to eq true
+    context "on an account with misc errors, like pick up card" do
+      let(:test_account) { Vantiv::TestAccount.pick_up_card }
+
+      it "returns a failure response" do
+        expect(response.success?).to eq false
+        expect(response.failure?).to eq true
+      end
+
+      it "returns a transaction ID" do
+        expect(response.transaction_id).not_to eq nil
+        expect(response.transaction_id).not_to eq ""
+      end
+
+      it "gives a human readable reason" do
+        expect(response.message).not_to eq nil
+        expect(response.message).not_to eq ""
+      end
+
+      it "returns a '303' response code" do
+        expect(response.response_code).to eq('303')
+      end
     end
 
-    it "returns a '110' response code" do
-      expect(response.response_code).to eq('110')
-    end
-  end
+    context "when API level failure occurs" do
+      let(:test_account) { Vantiv::TestAccount.valid_account }
 
-  context "on an account with an invalid account number" do
-    let(:test_account) { Vantiv::TestAccount.invalid_account_number }
+      before do
+        @vantiv_user = Vantiv.user
+        Vantiv.user = "fake_user"
+      end
 
-    it "returns a failure response" do
-      expect(response.success?).to eq false
-      expect(response.failure?).to eq true
-    end
+      after do
+        Vantiv.user = @vantiv_user
+      end
 
-    it "returns a transaction ID" do
-      expect(response.transaction_id).not_to eq nil
-      expect(response.transaction_id).not_to eq ""
-    end
-
-    it "gives a human readable reason" do
-      expect(response.message).to match(/invalid account number/i)
-    end
-
-    it "responds to invalid_account_number?" do
-      expect(response.invalid_account_number?).to eq true
-    end
-
-    it "returns a '301' response code" do
-      expect(response.response_code).to eq('301')
-    end
-  end
-
-  context "on an account with misc errors, like pick up card" do
-    let(:test_account) { Vantiv::TestAccount.pick_up_card }
-
-    it "returns a failure response" do
-      expect(response.success?).to eq false
-      expect(response.failure?).to eq true
-    end
-
-    it "returns a transaction ID" do
-      expect(response.transaction_id).not_to eq nil
-      expect(response.transaction_id).not_to eq ""
-    end
-
-    it "gives a human readable reason" do
-      expect(response.message).not_to eq nil
-      expect(response.message).not_to eq ""
-    end
-
-    it "returns a '303' response code" do
-      expect(response.response_code).to eq('303')
-    end
-  end
-
-  context "when API level failure occurs" do
-    let(:test_account) { Vantiv::TestAccount.valid_account }
-
-    before do
-      @license_id = Vantiv.license_id
-      Vantiv.license_id = "invalid"
-    end
-
-    after do
-      Vantiv.license_id = @license_id
-    end
-
-    it "responds that the authorization failed" do
-      expect(response.failure?).to eq true
-      expect(response.api_level_failure?).to eq true
+      it "responds that the authorization failed" do
+        expect(response.failure?).to eq true
+        expect(response.api_level_failure?).to eq true
+      end
     end
   end
 end

--- a/spec/mocked_sandbox/auth_capture_spec.rb
+++ b/spec/mocked_sandbox/auth_capture_spec.rb
@@ -24,7 +24,8 @@ describe "mocked API requests to auth_capture" do
       customer_id: customer_id,
       order_id: order_id,
       expiry_month: card.expiry_month,
-      expiry_year: card.expiry_year
+      expiry_year: card.expiry_year,
+      use_xml: use_xml
     )
     Vantiv::MockedSandbox.disable_self_mocked_requests!
     response
@@ -38,70 +39,142 @@ describe "mocked API requests to auth_capture" do
       customer_id: customer_id,
       order_id: order_id,
       expiry_month: card.expiry_month,
-      expiry_year: card.expiry_year
+      expiry_year: card.expiry_year,
+      use_xml: use_xml
     )
   end
 
   after { Vantiv::MockedSandbox.disable_self_mocked_requests! }
 
-  Vantiv::TestCard.all.each do |test_card|
-    next unless test_card.tokenizable?
+  context "when use_xml is false" do
+    let(:use_xml) { false }
 
-    let(:card) { test_card }
+    Vantiv::TestCard.all.each do |test_card|
+      next unless test_card.tokenizable?
 
-    context "with a #{test_card.name}" do
-      it "the mocked response's public methods return the same as the live one" do
-        (
+      let(:card) { test_card }
+
+      context "with a #{test_card.name}" do
+        it "the mocked response's public methods return the same as the live one" do
+          (
           Vantiv::Api::LiveTransactionResponse.instance_methods(false) +
-          Vantiv::Api::Response.instance_methods(false) -
-          [:payment_account_id, :body, :raw_body, :load, :request_id, :transaction_id, :account_updater]
-        ).each do |method_name|
-          next if method_name.to_s.end_with?("=")
+            Vantiv::Api::Response.instance_methods(false) -
+            [:payment_account_id, :body, :raw_body, :load, :request_id, :transaction_id, :account_updater]
+          ).each do |method_name|
+            next if method_name.to_s.end_with?("=")
 
-          live_response_value = live_response.send(method_name)
-          mocked_response_value = mocked_response.send(method_name)
-          expect(mocked_response_value).to eq(live_response_value),
-            error_message_for_mocked_api_failure(
-              method_name: method_name,
-              expected_value: live_response_value,
-              got_value: mocked_response_value,
-              live_response: live_response
-            )
+            live_response_value = live_response.send(method_name)
+            mocked_response_value = mocked_response.send(method_name)
+            expect(mocked_response_value).to eq(live_response_value),
+                                             error_message_for_mocked_api_failure(
+                                               method_name: method_name,
+                                               expected_value: live_response_value,
+                                               got_value: mocked_response_value,
+                                               live_response: live_response
+                                             )
+          end
+        end
+
+        it "returns a raw body string" do
+          expect(mocked_response.raw_body).to be_an_instance_of String
+        end
+
+        it "returns a dynamic transaction id" do
+          response_1 = run_mocked_response
+          response_2 = run_mocked_response
+          expect(response_1.transaction_id).not_to eq response_2.transaction_id
+        end
+
+        context "when the response has account updater information" do
+          let(:live_account_updater_response) { live_response.account_updater }
+          let(:mocked_account_updater_response) { mocked_response.account_updater }
+
+          it "has an equivalent payment_account_id" do
+            expect(mocked_account_updater_response.payment_account_id).to eq live_account_updater_response.payment_account_id
+          end
+
+          it "has an equivalent card_type" do
+            expect(mocked_account_updater_response.card_type).to eq live_account_updater_response.card_type
+          end
+
+          it "has an equivalent expiry_month" do
+            expect(mocked_account_updater_response.expiry_month).to eq live_account_updater_response.expiry_month
+          end
+
+          it "has an equivalent expiry_year" do
+            expect(mocked_account_updater_response.expiry_year).to eq live_account_updater_response.expiry_year
+          end
+
+          it "has an equivalent extended_card_response_code" do
+            expect(mocked_account_updater_response.extended_card_response_code).to eq live_account_updater_response.extended_card_response_code
+          end
         end
       end
+    end
+  end
 
-      it "returns a raw body string" do
-        expect(mocked_response.raw_body).to be_an_instance_of String
-      end
+  context "when use_xml is true" do
+    let(:use_xml) { true }
 
-      it "returns a dynamic transaction id" do
-        response_1 = run_mocked_response
-        response_2 = run_mocked_response
-        expect(response_1.transaction_id).not_to eq response_2.transaction_id
-      end
+    Vantiv::TestCard.all.each do |test_card|
+      next unless test_card.tokenizable?
 
-      context "when the response has account updater information" do
-        let(:live_account_updater_response) { live_response.account_updater }
-        let(:mocked_account_updater_response) { mocked_response.account_updater }
+      let(:card) { test_card }
 
-        it "has an equivalent payment_account_id" do
-          expect(mocked_account_updater_response.payment_account_id).to eq live_account_updater_response.payment_account_id
+      context "with a #{test_card.name}" do
+        it "the mocked response's public methods return the same as the live one" do
+          (
+          Vantiv::Api::LiveTransactionResponse.instance_methods(false) +
+            Vantiv::Api::Response.instance_methods(false) -
+            [:payment_account_id, :body, :raw_body, :load, :request_id, :transaction_id, :account_updater]
+          ).each do |method_name|
+            next if method_name.to_s.end_with?("=")
+
+            live_response_value = live_response.send(method_name)
+            mocked_response_value = mocked_response.send(method_name)
+            expect(mocked_response_value).to eq(live_response_value),
+                                             error_message_for_mocked_api_failure(
+                                               method_name: method_name,
+                                               expected_value: live_response_value,
+                                               got_value: mocked_response_value,
+                                               live_response: live_response
+                                             )
+          end
         end
 
-        it "has an equivalent card_type" do
-          expect(mocked_account_updater_response.card_type).to eq live_account_updater_response.card_type
+        it "returns a raw body string" do
+          expect(mocked_response.raw_body).to be_an_instance_of String
         end
 
-        it "has an equivalent expiry_month" do
-          expect(mocked_account_updater_response.expiry_month).to eq live_account_updater_response.expiry_month
+        it "returns a dynamic transaction id" do
+          response_1 = run_mocked_response
+          response_2 = run_mocked_response
+          expect(response_1.transaction_id).not_to eq response_2.transaction_id
         end
 
-        it "has an equivalent expiry_year" do
-          expect(mocked_account_updater_response.expiry_year).to eq live_account_updater_response.expiry_year
-        end
+        context "when the response has account updater information" do
+          let(:live_account_updater_response) { live_response.account_updater }
+          let(:mocked_account_updater_response) { mocked_response.account_updater }
 
-        it "has an equivalent extended_card_response_code" do
-          expect(mocked_account_updater_response.extended_card_response_code).to eq live_account_updater_response.extended_card_response_code
+          it "has an equivalent payment_account_id" do
+            expect(mocked_account_updater_response.payment_account_id).to eq live_account_updater_response.payment_account_id
+          end
+
+          it "has an equivalent card_type" do
+            expect(mocked_account_updater_response.card_type).to eq live_account_updater_response.card_type
+          end
+
+          it "has an equivalent expiry_month" do
+            expect(mocked_account_updater_response.expiry_month).to eq live_account_updater_response.expiry_month
+          end
+
+          it "has an equivalent expiry_year" do
+            expect(mocked_account_updater_response.expiry_year).to eq live_account_updater_response.expiry_year
+          end
+
+          it "has an equivalent extended_card_response_code" do
+            expect(mocked_account_updater_response.extended_card_response_code).to eq live_account_updater_response.extended_card_response_code
+          end
         end
       end
     end


### PR DESCRIPTION
* adds use_xml flag to Vantiv.auth_capture
* adds tests with use_xml set to true and false