### PR TITLE
rename Vantiv.order_source to Vantiv.default_order_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The gem needs the following configuration to be set on app initialization. It is
 Vantiv.configure do |config|
   config.license_id = ENV["VANTIV_LICENSE_ID"]
   config.acceptor_id = ENV["VANTIV_ACCEPTOR_ID"]
-  config.order_source = "desired-order-source"
+  config.default_order_source = "desired-order-source"
   config.paypage_id = ENV["VANTIV_PAYPAGE_ID"]
   
   config.user = ENV["VANTIV_USER"]

--- a/bin/console
+++ b/bin/console
@@ -9,7 +9,7 @@ Vantiv.configure do |config|
   config.environment = Vantiv::Environment::CERTIFICATION
   config.license_id = ENV["LICENSE_ID"]
   config.acceptor_id = ENV["ACCEPTOR_ID"]
-  config.order_source = "ecommerce"
+  config.default_order_source = "ecommerce"
   config.paypage_id = ENV["PAYPAGE_ID"]
 
   config.user = ENV["VANTIV_USER"]

--- a/bin/generate_sandbox_fixtures
+++ b/bin/generate_sandbox_fixtures
@@ -9,7 +9,7 @@ Vantiv.configure do |config|
   config.environment = Vantiv::Environment::CERTIFICATION
   config.license_id = ENV["LICENSE_ID"]
   config.acceptor_id = ENV["ACCEPTOR_ID"]
-  config.order_source = "ecommerce"
+  config.default_order_source = "ecommerce"
   config.paypage_id = ENV["PAYPAGE_ID"]
 
   config.user = ENV["VANTIV_USER"]

--- a/bin/paypage_server
+++ b/bin/paypage_server
@@ -10,7 +10,7 @@ Vantiv.configure do |config|
   config.environment = Vantiv::Environment::CERTIFICATION
   config.license_id = ENV["LICENSE_ID"]
   config.acceptor_id = ENV["ACCEPTOR_ID"]
-  config.order_source = "ecommerce"
+  config.default_order_source = "ecommerce"
   config.paypage_id = ENV["PAYPAGE_ID"]
 
   config.user = ENV["VANTIV_USER"]

--- a/lib/vantiv.rb
+++ b/lib/vantiv.rb
@@ -146,7 +146,7 @@ module Vantiv
   class << self
     [
       :environment, :license_id, :acceptor_id, :default_report_group,
-      :order_source, :paypage_id, :user, :password
+      :default_order_source, :paypage_id, :user, :password
     ].each do |config_var|
       define_method :"#{config_var}" do
         value = instance_variable_get(:"@#{config_var}")

--- a/lib/vantiv/api/request_body.rb
+++ b/lib/vantiv/api/request_body.rb
@@ -42,7 +42,7 @@ module Vantiv
         transaction = Transaction.new(
             order_id: order_id,
             amount_in_cents: amount,
-            order_source: Vantiv.order_source,
+            order_source: Vantiv.default_order_source,
             customer_id: customer_id,
             partial_approved_flag: false
         )
@@ -78,7 +78,7 @@ module Vantiv
         transaction = Transaction.new(
           order_id: order_id,
           amount_in_cents: amount,
-          order_source: Vantiv.order_source,
+          order_source: Vantiv.default_order_source,
           customer_id: customer_id
         )
         card = Card.new(

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -4,7 +4,7 @@ describe "Vantiv configuration" do
   [:license_id,
    :acceptor_id,
    :default_report_group,
-   :order_source,
+   :default_order_source,
    :paypage_id,
    :user,
    :password

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ Vantiv.configure do |config|
   config.environment = Vantiv::Environment::CERTIFICATION
   config.license_id = ENV["LICENSE_ID"]
   config.acceptor_id = ENV["ACCEPTOR_ID"]
-  config.order_source = "ecommerce"
+  config.default_order_source = "ecommerce"
   config.paypage_id = ENV["PAYPAGE_ID"]
 
   config.user = ENV["VANTIV_USER"]


### PR DESCRIPTION
**Includes breaking changes**
* `Vantiv.order_source` is renamed to `Vantiv.default_order_source` to prepare for parameterized order_source