### PR TITLE
Allow order_source to be passed into Vantiv.auth_capture and Vantiv.refund

### DIFF
--- a/lib/vantiv.rb
+++ b/lib/vantiv.rb
@@ -84,14 +84,16 @@ module Vantiv
     ).run
   end
 
-  def self.auth_capture(amount:, payment_account_id:, customer_id:, order_id:, expiry_month:, expiry_year:, use_xml: false)
+  def self.auth_capture(amount:, payment_account_id:, customer_id:, order_id:,
+      expiry_month:, expiry_year:, use_xml: false, order_source: Vantiv.default_order_source)
     body = Api::RequestBody.for_auth_or_sale(
       amount: amount,
       order_id: order_id,
       customer_id: customer_id,
       payment_account_id: payment_account_id,
       expiry_month: expiry_month,
-      expiry_year: expiry_year
+      expiry_year: expiry_year,
+      order_source: order_source
     )
     Api::Request.new(
       endpoint: Api::Endpoints::SALE,

--- a/lib/vantiv.rb
+++ b/lib/vantiv.rb
@@ -115,14 +115,16 @@ module Vantiv
     ).run
   end
 
-  def self.refund(amount:, payment_account_id:, customer_id:, order_id:, expiry_month:, expiry_year:)
+  def self.refund(amount:, payment_account_id:, customer_id:, order_id:,
+      expiry_month:, expiry_year:, order_source: Vantiv.default_order_source)
     body = Api::RequestBody.for_return(
       amount: amount,
       customer_id: customer_id,
       order_id: order_id,
       payment_account_id: payment_account_id,
       expiry_month: expiry_month,
-      expiry_year: expiry_year
+      expiry_year: expiry_year,
+      order_source: order_source
     )
     Api::Request.new(
       endpoint: Api::Endpoints::RETURN,

--- a/lib/vantiv/api/request_body.rb
+++ b/lib/vantiv/api/request_body.rb
@@ -74,11 +74,12 @@ module Vantiv
         new(transaction: transaction)
       end
 
-      def self.for_return(amount:, customer_id:, order_id:, payment_account_id:, expiry_month:, expiry_year:)
+      def self.for_return(amount:, customer_id:, order_id:, payment_account_id:,
+          expiry_month:, expiry_year:, order_source: Vantiv.default_order_source)
         transaction = Transaction.new(
           order_id: order_id,
           amount_in_cents: amount,
-          order_source: Vantiv.default_order_source,
+          order_source: order_source,
           customer_id: customer_id
         )
         card = Card.new(

--- a/lib/vantiv/api/request_body.rb
+++ b/lib/vantiv/api/request_body.rb
@@ -38,11 +38,12 @@ module Vantiv
         ::RequestBodyRepresenterXml.new(self).to_xml
       end
 
-      def self.for_auth_or_sale(amount:, customer_id:, order_id:, payment_account_id:, expiry_month:, expiry_year:)
+      def self.for_auth_or_sale(amount:, customer_id:, order_id:, payment_account_id:,
+          expiry_month:, expiry_year:, order_source: Vantiv.default_order_source)
         transaction = Transaction.new(
             order_id: order_id,
             amount_in_cents: amount,
-            order_source: Vantiv.default_order_source,
+            order_source: order_source,
             customer_id: customer_id,
             partial_approved_flag: false
         )

--- a/spec/api/request_body_spec.rb
+++ b/spec/api/request_body_spec.rb
@@ -151,6 +151,24 @@ describe Vantiv::Api::RequestBody do
   end
 
   describe ".for_auth_or_sale" do
+    context "when order source is passed in" do
+      subject(:request_body) do
+        Vantiv::Api::RequestBody.for_auth_or_sale(
+          amount: 4224,
+          customer_id: "extid123",
+          payment_account_id: "paymentacct123",
+          order_id: "SomeOrder123",
+          expiry_month: "8",
+          expiry_year: "2018",
+          order_source: "my-custom-order-source"
+        )
+      end
+
+      it "sets the order source on the transaction" do
+        expect(request_body.transaction.order_source).to eq "my-custom-order-source"
+      end
+    end
+
     subject(:request_body) do
       Vantiv::Api::RequestBody.for_auth_or_sale(
         amount: 4224,

--- a/spec/api/request_body_spec.rb
+++ b/spec/api/request_body_spec.rb
@@ -422,13 +422,6 @@ describe Vantiv::Api::RequestBody do
       it "sets the order source on the response body" do
         expect(request_body.transaction.order_source).to eq "my-custom-order-source"
       end
-
-      it "uses the correct order source when converted to json" do
-        allow(SecureRandom).to receive(:hex).and_return "the-application-id"
-        allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-        expected = {"Credentials"=>{"AcceptorID"=>"acceptor-id"}, "Reports"=>{"ReportGroup"=>"1"}, "Application"=>{"ApplicationID"=>"the-application-id"}, "Transaction"=>{"ReferenceNumber"=>"SomeOrder123", "TransactionAmount"=>"42.24", "OrderSource"=>"my-custom-order-source", "CustomerID"=>"extid123"}, "Card"=>{"ExpirationMonth"=>"08", "ExpirationYear"=>"18"}, "PaymentAccount"=>{"PaymentAccountID"=>"paymentacct123"}}
-        expect(request_body.to_json).to eq expected.to_json
-      end
     end
 
     it "returns the expected json" do

--- a/spec/auth_capture_spec.rb
+++ b/spec/auth_capture_spec.rb
@@ -127,6 +127,49 @@ describe "auth_capture (Sale)" do
         expect(response.api_level_failure?).to eq true
       end
     end
+
+    context "when no order source is passed in" do
+      let(:test_account) { Vantiv::TestAccount.valid_account }
+
+      before do
+        allow_any_instance_of(Vantiv::Api::Request).to receive :run
+      end
+
+      it "uses the default order_source" do
+        expect(Vantiv::Api::RequestBody).to receive(:for_auth_or_sale).with(
+          hash_including(order_source: Vantiv.default_order_source)
+        )
+        response
+      end
+    end
+
+    context "when an order source is passed in" do
+      let(:test_account) { Vantiv::TestAccount.valid_account }
+
+      subject(:response) do
+        Vantiv.auth_capture(
+          amount: 10000,
+          payment_account_id: payment_account_id,
+          customer_id: customer_external_id,
+          order_id: "SomeOrder123",
+          expiry_month: test_account.expiry_month,
+          expiry_year: test_account.expiry_year,
+          use_xml: use_xml,
+          order_source: "custom-order-source"
+        )
+      end
+
+      before do
+        allow_any_instance_of(Vantiv::Api::Request).to receive :run
+      end
+
+      it "uses the default order_source" do
+        expect(Vantiv::Api::RequestBody).to receive(:for_auth_or_sale).with(
+          hash_including(order_source: "custom-order-source")
+        )
+        response
+      end
+    end
   end
 
   context "when use_xml is false" do
@@ -241,6 +284,53 @@ describe "auth_capture (Sale)" do
       it "responds that the authorization failed" do
         expect(response.failure?).to eq true
         expect(response.api_level_failure?).to eq true
+      end
+    end
+
+    context "when no order source is passed in" do
+      let(:test_account) { Vantiv::TestAccount.valid_account }
+
+      before do
+        request_double = double('request')
+        allow(Vantiv::Api::Request).to receive(:new) { request_double }
+        allow(request_double).to receive :run
+      end
+
+      it "uses the default order_source" do
+        expect(Vantiv::Api::RequestBody).to receive(:for_auth_or_sale).with(
+          hash_including(order_source: Vantiv.default_order_source)
+        )
+        response
+      end
+    end
+
+    context "when an order source is passed in" do
+      let(:test_account) { Vantiv::TestAccount.valid_account }
+
+      subject(:response) do
+        Vantiv.auth_capture(
+          amount: 10000,
+          payment_account_id: payment_account_id,
+          customer_id: customer_external_id,
+          order_id: "SomeOrder123",
+          expiry_month: test_account.expiry_month,
+          expiry_year: test_account.expiry_year,
+          use_xml: use_xml,
+          order_source: "custom-order-source"
+        )
+      end
+
+      before do
+        request_double = double('request')
+        allow(Vantiv::Api::Request).to receive(:new) { request_double }
+        allow(request_double).to receive :run
+      end
+
+      it "uses the default order_source" do
+        expect(Vantiv::Api::RequestBody).to receive(:for_auth_or_sale).with(
+          hash_including(order_source: "custom-order-source")
+        )
+        response
       end
     end
   end

--- a/spec/refund_spec.rb
+++ b/spec/refund_spec.rb
@@ -20,6 +20,44 @@ describe "processing standalone refunds" do
     )
   end
 
+  context "when no order source is passed in" do
+    before do
+      allow_any_instance_of(Vantiv::Api::Request).to receive :run
+    end
+
+    it "uses the default order_source" do
+      expect(Vantiv::Api::RequestBody).to receive(:for_return).with(
+        hash_including(order_source: Vantiv.default_order_source)
+      )
+      response
+    end
+  end
+
+  context "when an order source is passed in" do
+    subject(:response) do
+      Vantiv.refund(
+        amount: 10000,
+        customer_id: "cust-id-123",
+        order_id: order_id,
+        payment_account_id: payment_account_id,
+        expiry_month: test_account.expiry_month,
+        expiry_year: test_account.expiry_year,
+        order_source: "custom-order-source"
+      )
+    end
+
+    before do
+      allow_any_instance_of(Vantiv::Api::Request).to receive :run
+    end
+
+    it "uses the default order_source" do
+      expect(Vantiv::Api::RequestBody).to receive(:for_return).with(
+        hash_including(order_source: "custom-order-source")
+      )
+      response
+    end
+  end
+
   it "returns success when transaction is received" do
     expect(response.success?).to eq true
   end


### PR DESCRIPTION
* allow order_source to be passed into RequestBody.for_return
* allow order_source to be passed into Vantiv.refund
* allow order_source to be passed into RequestBody.for_auth_or_sale
* allow order_source to be passed into Vantiv.auth_capture