### PR TITLE
allow order source to be passed into auth requests

### DIFF
--- a/lib/vantiv.rb
+++ b/lib/vantiv.rb
@@ -43,7 +43,7 @@ module Vantiv
   end
 
   def self.auth(amount:, payment_account_id:, customer_id:, order_id:, expiry_month:, expiry_year:,
-      use_temporarily_stored_security_code: false, use_xml: false)
+    order_source: Vantiv.default_order_source, use_temporarily_stored_security_code: false, use_xml: false)
 
     # From XML Docs:
     # When you submit the CVV2/CVC2/CID in a registerTokenRequest, the platform encrypts
@@ -60,7 +60,8 @@ module Vantiv
       payment_account_id: payment_account_id,
       expiry_month: expiry_month,
       expiry_year: expiry_year,
-      cvv: cvv
+      cvv: cvv,
+      order_source: order_source
     )
     Api::Request.new(
       endpoint: Api::Endpoints::AUTHORIZATION,

--- a/spec/auth_capture_spec.rb
+++ b/spec/auth_capture_spec.rb
@@ -326,7 +326,7 @@ describe "auth_capture (Sale)" do
         allow(request_double).to receive :run
       end
 
-      it "uses the default order_source" do
+      it "uses the passed in order_source" do
         expect(Vantiv::Api::RequestBody).to receive(:for_auth_or_sale).with(
           hash_including(order_source: "custom-order-source")
         )

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -283,6 +283,54 @@ describe "auth" do
         expect(response.api_level_failure?).to eq true
       end
     end
+
+    context "when no order source is passed in" do
+      let(:test_account) { Vantiv::TestAccount.valid_account }
+
+      before do
+        request_double = double('request')
+        allow(Vantiv::Api::Request).to receive(:new) { request_double }
+        allow(request_double).to receive :run
+      end
+
+      it "uses the default order_source" do
+        expect(Vantiv::Api::RequestBody).to receive(:for_auth_or_sale).with(
+          hash_including(order_source: Vantiv.default_order_source)
+        )
+        response
+      end
+    end
+
+    context "when an order source is passed in" do
+      let(:test_account) { Vantiv::TestAccount.valid_account }
+
+      subject(:response) do
+        Vantiv.auth_capture(
+          amount: 10000,
+          payment_account_id: payment_account_id,
+          customer_id: customer_external_id,
+          order_id: "SomeOrder123",
+          expiry_month: test_account.expiry_month,
+          expiry_year: test_account.expiry_year,
+          use_xml: use_xml,
+          order_source: "custom-order-source"
+        )
+      end
+
+      before do
+        request_double = double('request')
+        allow(Vantiv::Api::Request).to receive(:new) { request_double }
+        allow(request_double).to receive :run
+      end
+
+      it "uses the default order_source" do
+        expect(Vantiv::Api::RequestBody).to receive(:for_auth_or_sale).with(
+          hash_including(order_source: "custom-order-source")
+        )
+        response
+      end
+    end
+
   end
 
 end

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -323,7 +323,7 @@ describe "auth" do
         allow(request_double).to receive :run
       end
 
-      it "uses the default order_source" do
+      it "uses the passed in order_source" do
         expect(Vantiv::Api::RequestBody).to receive(:for_auth_or_sale).with(
           hash_including(order_source: "custom-order-source")
         )


### PR DESCRIPTION
We need to change the order source for ApplePay transactions