### PR TITLE
rename acceptor id to merchant id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # This is an example .env file
-ACCEPTOR_ID="paste-vantiv-acceptor-id-here"
+MERCHANT_ID="paste-vantiv-merchant-id-here"
 PAYPAGE_ID="paste-vantiv-paypage-id-here"
 
 VANTIV_USER="paste-xml-user-here"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The gem needs the following configuration to be set on app initialization. It is
 
 ```ruby
 Vantiv.configure do |config|
-  config.acceptor_id = ENV["VANTIV_ACCEPTOR_ID"]
+  config.merchant_id = ENV["VANTIV_MERCHANT_ID"]
   config.default_order_source = "desired-order-source"
   config.paypage_id = ENV["VANTIV_PAYPAGE_ID"]
   
@@ -44,7 +44,7 @@ Vantiv requires merchants to certify their applications for usage with their API
 To certify your application, run the following script:
 
 ```
-$ bundle exec vantiv-certify-app -a sub-your-acceptor-id-in-here -p your-paypage-id -u your-user -w your-password
+$ bundle exec vantiv-certify-app -a sub-your-merchant-id-in-here -p your-paypage-id -u your-user -w your-password
 ```
 
 A certs.txt file will be generated in the directory that the script is run, and then opened. It contains a list of XML Certification Order IDs and associated Transaction IDs, like follows:

--- a/bin/console
+++ b/bin/console
@@ -7,7 +7,7 @@ require "dotenv"
 Dotenv.load
 Vantiv.configure do |config|
   config.environment = Vantiv::Environment::CERTIFICATION
-  config.acceptor_id = ENV["ACCEPTOR_ID"]
+  config.merchant_id = ENV["MERCHANT_ID"]
   config.default_order_source = "ecommerce"
   config.paypage_id = ENV["PAYPAGE_ID"]
 

--- a/bin/generate_sandbox_fixtures
+++ b/bin/generate_sandbox_fixtures
@@ -7,7 +7,7 @@ require "dotenv"
 Dotenv.load
 Vantiv.configure do |config|
   config.environment = Vantiv::Environment::CERTIFICATION
-  config.acceptor_id = ENV["ACCEPTOR_ID"]
+  config.merchant_id = ENV["MERCHANT_ID"]
   config.default_order_source = "ecommerce"
   config.paypage_id = ENV["PAYPAGE_ID"]
 

--- a/bin/paypage_server
+++ b/bin/paypage_server
@@ -8,7 +8,7 @@ require "vantiv/certification/paypage_server"
 
 Vantiv.configure do |config|
   config.environment = Vantiv::Environment::CERTIFICATION
-  config.acceptor_id = ENV["ACCEPTOR_ID"]
+  config.merchant_id = ENV["MERCHANT_ID"]
   config.default_order_source = "ecommerce"
   config.paypage_id = ENV["PAYPAGE_ID"]
 

--- a/exe/vantiv-certify-app
+++ b/exe/vantiv-certify-app
@@ -6,10 +6,10 @@ require 'optparse'
 
 options = {}
 parser = OptionParser.new do |opts|
-  opts.banner = "Usage: vantiv-certify-app -a <acceptor_id> -p <paypage_id> -u <user> -w <password> [--filter_by <test_name>]"
+  opts.banner = "Usage: vantiv-certify-app -a <merchant_id> -p <paypage_id> -u <user> -w <password> [--filter_by <test_name>]"
 
-  opts.on("-a", "--acceptor_id ACCEPTOR_ID", "Vantiv Acceptor ID") do |acceptor_id|
-    options[:acceptor_id] = acceptor_id
+  opts.on("-a", "--merchant_id MERCHANT_ID", "Vantiv Merchant ID") do |merchant_id|
+    options[:merchant_id] = merchant_id
   end
 
   opts.on("-p", "--paypage_id PAYPAGE_ID", "Vantiv Paypage ID") do |paypage_id|
@@ -31,7 +31,7 @@ end
 
 parser.parse!
 
-required_arguments = %i[acceptor_id paypage_id user password]
+required_arguments = %i[merchant_id paypage_id user password]
 missing_arguments = required_arguments.select{ |required_argument| options[required_argument].nil? }
 
 if missing_arguments.any?
@@ -41,7 +41,7 @@ if missing_arguments.any?
 end
 
 Vantiv.configure do |config|
-  config.acceptor_id = options.fetch(:acceptor_id)
+  config.merchant_id = options.fetch(:merchant_id)
   config.paypage_id = options.fetch(:paypage_id)
   config.environment = Vantiv::Environment::CERTIFICATION
 

--- a/lib/vantiv.rb
+++ b/lib/vantiv.rb
@@ -163,7 +163,7 @@ module Vantiv
   end
 
   class << self
-    %i[ environment acceptor_id default_report_group
+    %i[ environment merchant_id default_report_group
         default_order_source paypage_id user password ].freeze.each do |config_var|
 
       define_method(config_var) do

--- a/lib/vantiv/api/request_body.rb
+++ b/lib/vantiv/api/request_body.rb
@@ -13,7 +13,7 @@ module Vantiv
     end
 
     class RequestBody
-      attr_reader :acceptor_id, :application_id, :report_group
+      attr_reader :merchant_id, :application_id, :report_group
       attr_accessor :card, :transaction, :payment_account, :address
 
       attr_accessor :version, :authentication, :xmlns
@@ -23,7 +23,7 @@ module Vantiv
         @transaction = transaction
         @payment_account = payment_account
 
-        @acceptor_id = Vantiv.acceptor_id
+        @merchant_id = Vantiv.merchant_id
         @application_id = SecureRandom.hex(12)
         @report_group = Vantiv.default_report_group
 

--- a/lib/vantiv/api/request_body_representer.rb
+++ b/lib/vantiv/api/request_body_representer.rb
@@ -8,7 +8,7 @@ class RequestBodyRepresenter < Representable::Decorator
   include Representable::JSON
 
   nested :Credentials do
-    property :acceptor_id, as: :AcceptorID
+    property :merchant_id, as: :AcceptorID
   end
 
   nested :Reports do

--- a/lib/vantiv/api/request_body_representer_xml.rb
+++ b/lib/vantiv/api/request_body_representer_xml.rb
@@ -8,7 +8,7 @@ class RequestBodyRepresenterXml < Representable::Decorator
 
   property :version, attribute: true
   property :xmlns, attribute: true
-  property :acceptor_id, as: :merchantId, attribute: true
+  property :merchant_id, as: :merchantId, attribute: true
 
   property :authentication, class: Vantiv::Api::Authentication, as: :authentication do
     property :user

--- a/spec/api/request_body_spec.rb
+++ b/spec/api/request_body_spec.rb
@@ -1,6 +1,21 @@
 require 'spec_helper'
 
 describe Vantiv::Api::RequestBody do
+  shared_examples "a request body" do
+    it "includes the merchant id" do
+      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+      expect(request_body.merchant_id).to eq "merchant-id"
+    end
+
+    it "includes the default report group" do
+      expect(request_body.report_group).to eq Vantiv.default_report_group
+    end
+
+    it "include the application id" do
+      expect(request_body.application_id).to be
+    end
+  end
+
   describe ".for_direct_post_tokenization" do
     let(:card_number) { 1234 }
     let(:expiry_month) { 10 }
@@ -16,18 +31,7 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
-    it "includes the merchant id" do
-      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-      expect(request_body.merchant_id).to eq "merchant-id"
-    end
-
-    it "includes the default report group" do
-      expect(request_body.report_group).to eq "1"
-    end
-
-    it "include the application id" do
-      expect(request_body.application_id).to be
-    end
+    it_behaves_like "a request body"
 
     it "includes stringified versions of card params" do
       expect(request_body.card.account_number).to eq card_number.to_s
@@ -48,18 +52,7 @@ describe Vantiv::Api::RequestBody do
       @paypage_registration_id = "some-temp-token"
     end
 
-    it "includes the merchant id" do
-      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-      expect(request_body.merchant_id).to eq "merchant-id"
-    end
-
-    it "includes the default report group" do
-      expect(request_body.report_group).to eq "1"
-    end
-
-    it "include the application id" do
-      expect(request_body.application_id).to be
-    end
+    it_behaves_like "a request body"
 
     it "includes the paypage registration id" do
       expect(request_body.card.paypage_registration_id).to eq "some-temp-token"
@@ -74,22 +67,11 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
+    it_behaves_like "a request body"
+
     context "when amount is nil" do
       before do
         @amount = nil
-      end
-
-      it "includes the merchant id" do
-        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-        expect(request_body.merchant_id).to eq "merchant-id"
-      end
-
-      it "includes the default report group" do
-        expect(request_body.report_group).to eq "1"
-      end
-
-      it "include the application id" do
-        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
@@ -106,19 +88,6 @@ describe Vantiv::Api::RequestBody do
         @amount = 58888
       end
 
-      it "includes the merchant id" do
-        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-        expect(request_body.merchant_id).to eq "merchant-id"
-      end
-
-      it "includes the default report group" do
-        expect(request_body.report_group).to eq "1"
-      end
-
-      it "include the application id" do
-        expect(request_body.application_id).to be
-      end
-
       it "includes the transaction id" do
         expect(request_body.transaction.id).to eq "transactionid123"
       end
@@ -130,6 +99,19 @@ describe Vantiv::Api::RequestBody do
   end
 
   describe ".for_auth_or_sale" do
+    subject(:request_body) do
+      Vantiv::Api::RequestBody.for_auth_or_sale(
+        amount: 4224,
+        customer_id: "extid123",
+        payment_account_id: "paymentacct123",
+        order_id: "SomeOrder123",
+        expiry_month: "8",
+        expiry_year: "2018"
+      )
+    end
+
+    it_behaves_like "a request body"
+
     context "when order source is passed in" do
       subject(:request_body) do
         Vantiv::Api::RequestBody.for_auth_or_sale(
@@ -182,30 +164,6 @@ describe Vantiv::Api::RequestBody do
       it "sets cardholder authentication to nil" do
         expect(request_body.transaction.cardholder_authentication).to eq nil
       end
-    end
-
-    subject(:request_body) do
-      Vantiv::Api::RequestBody.for_auth_or_sale(
-        amount: 4224,
-        customer_id: "extid123",
-        payment_account_id: "paymentacct123",
-        order_id: "SomeOrder123",
-        expiry_month: "8",
-        expiry_year: "2018"
-      )
-    end
-
-    it "includes the merchant id" do
-      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-      expect(request_body.merchant_id).to eq "merchant-id"
-    end
-
-    it "includes the default report group" do
-      expect(request_body.report_group).to eq "1"
-    end
-
-    it "include the application id" do
-      expect(request_body.application_id).to be
     end
 
     context "Transaction object" do
@@ -274,22 +232,11 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
+    it_behaves_like "a request body"
+
     context "when amount is nil" do
       before do
         @amount = nil
-      end
-
-      it "includes the merchant id" do
-        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-        expect(request_body.merchant_id).to eq "merchant-id"
-      end
-
-      it "includes the default report group" do
-        expect(request_body.report_group).to eq "1"
-      end
-
-      it "include the application id" do
-        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
@@ -304,19 +251,6 @@ describe Vantiv::Api::RequestBody do
     context "when amount is not nil" do
       before do
         @amount = 58888
-      end
-
-      it "includes the merchant id" do
-        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-        expect(request_body.merchant_id).to eq "merchant-id"
-      end
-
-      it "includes the default report group" do
-        expect(request_body.report_group).to eq "1"
-      end
-
-      it "include the application id" do
-        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
@@ -337,22 +271,11 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
+    it_behaves_like "a request body"
+
     context "when amount is nil" do
       before do
         @amount = nil
-      end
-
-      it "includes the merchant id" do
-        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-        expect(request_body.merchant_id).to eq "merchant-id"
-      end
-
-      it "includes the default report group" do
-        expect(request_body.report_group).to eq "1"
-      end
-
-      it "include the application id" do
-        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
@@ -367,19 +290,6 @@ describe Vantiv::Api::RequestBody do
     context "when amount is not nil" do
       before do
         @amount = 58888
-      end
-
-      it "includes the merchant id" do
-        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-        expect(request_body.merchant_id).to eq "merchant-id"
-      end
-
-      it "includes the default report group" do
-        expect(request_body.report_group).to eq "1"
-      end
-
-      it "include the application id" do
-        expect(request_body.application_id).to be
       end
 
       it "includes the transaction id" do
@@ -404,6 +314,12 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
+    it_behaves_like "a request body"
+
+    it "includes the PaymentAccountID" do
+      expect(request_body.payment_account.id).to eq "paymentacct123"
+    end
+
     context "when order source is passed in" do
       subject(:request_body) do
         Vantiv::Api::RequestBody.for_return(
@@ -420,19 +336,6 @@ describe Vantiv::Api::RequestBody do
       it "sets the order source on the response body" do
         expect(request_body.transaction.order_source).to eq "my-custom-order-source"
       end
-    end
-
-    it "includes the merchant id" do
-      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-      expect(request_body.merchant_id).to eq "merchant-id"
-    end
-
-    it "includes the default report group" do
-      expect(request_body.report_group).to eq "1"
-    end
-
-    it "include the application id" do
-      expect(request_body.application_id).to be
     end
 
     context "Transaction object" do
@@ -474,10 +377,6 @@ describe Vantiv::Api::RequestBody do
         expect(request_body.card.expiry_year).to eq "18"
       end
     end
-
-    it "includes the PaymentAccountID" do
-      expect(request_body.payment_account.id).to eq "paymentacct123"
-    end
   end
 
   describe ".for_void" do
@@ -487,22 +386,10 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
-    it "includes the merchant id" do
-      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
-      expect(request_body.merchant_id).to eq "merchant-id"
-    end
-
-    it "includes the default report group" do
-      expect(request_body.report_group).to eq "1"
-    end
-
-    it "include the application id" do
-      expect(request_body.application_id).to be
-    end
+    it_behaves_like "a request body"
 
     it "includes the transaction id" do
       expect(request_body.transaction.id).to eq "transactionid123"
     end
   end
-
 end

--- a/spec/api/request_body_spec.rb
+++ b/spec/api/request_body_spec.rb
@@ -16,9 +16,9 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
-    it "includes the acceptor id" do
-      allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-      expect(request_body.acceptor_id).to eq "acceptor-id"
+    it "includes the merchant id" do
+      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+      expect(request_body.merchant_id).to eq "merchant-id"
     end
 
     it "includes the default report group" do
@@ -48,9 +48,9 @@ describe Vantiv::Api::RequestBody do
       @paypage_registration_id = "some-temp-token"
     end
 
-    it "includes the acceptor id" do
-      allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-      expect(request_body.acceptor_id).to eq "acceptor-id"
+    it "includes the merchant id" do
+      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+      expect(request_body.merchant_id).to eq "merchant-id"
     end
 
     it "includes the default report group" do
@@ -79,9 +79,9 @@ describe Vantiv::Api::RequestBody do
         @amount = nil
       end
 
-      it "includes the acceptor id" do
-        allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-        expect(request_body.acceptor_id).to eq "acceptor-id"
+      it "includes the merchant id" do
+        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+        expect(request_body.merchant_id).to eq "merchant-id"
       end
 
       it "includes the default report group" do
@@ -106,9 +106,9 @@ describe Vantiv::Api::RequestBody do
         @amount = 58888
       end
 
-      it "includes the acceptor id" do
-        allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-        expect(request_body.acceptor_id).to eq "acceptor-id"
+      it "includes the merchant id" do
+        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+        expect(request_body.merchant_id).to eq "merchant-id"
       end
 
       it "includes the default report group" do
@@ -195,9 +195,9 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
-    it "includes the acceptor id" do
-      allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-      expect(request_body.acceptor_id).to eq "acceptor-id"
+    it "includes the merchant id" do
+      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+      expect(request_body.merchant_id).to eq "merchant-id"
     end
 
     it "includes the default report group" do
@@ -279,9 +279,9 @@ describe Vantiv::Api::RequestBody do
         @amount = nil
       end
 
-      it "includes the acceptor id" do
-        allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-        expect(request_body.acceptor_id).to eq "acceptor-id"
+      it "includes the merchant id" do
+        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+        expect(request_body.merchant_id).to eq "merchant-id"
       end
 
       it "includes the default report group" do
@@ -306,9 +306,9 @@ describe Vantiv::Api::RequestBody do
         @amount = 58888
       end
 
-      it "includes the acceptor id" do
-        allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-        expect(request_body.acceptor_id).to eq "acceptor-id"
+      it "includes the merchant id" do
+        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+        expect(request_body.merchant_id).to eq "merchant-id"
       end
 
       it "includes the default report group" do
@@ -342,9 +342,9 @@ describe Vantiv::Api::RequestBody do
         @amount = nil
       end
 
-      it "includes the acceptor id" do
-        allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-        expect(request_body.acceptor_id).to eq "acceptor-id"
+      it "includes the merchant id" do
+        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+        expect(request_body.merchant_id).to eq "merchant-id"
       end
 
       it "includes the default report group" do
@@ -369,9 +369,9 @@ describe Vantiv::Api::RequestBody do
         @amount = 58888
       end
 
-      it "includes the acceptor id" do
-        allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-        expect(request_body.acceptor_id).to eq "acceptor-id"
+      it "includes the merchant id" do
+        allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+        expect(request_body.merchant_id).to eq "merchant-id"
       end
 
       it "includes the default report group" do
@@ -422,9 +422,9 @@ describe Vantiv::Api::RequestBody do
       end
     end
 
-    it "includes the acceptor id" do
-      allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-      expect(request_body.acceptor_id).to eq "acceptor-id"
+    it "includes the merchant id" do
+      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+      expect(request_body.merchant_id).to eq "merchant-id"
     end
 
     it "includes the default report group" do
@@ -487,9 +487,9 @@ describe Vantiv::Api::RequestBody do
       )
     end
 
-    it "includes the acceptor id" do
-      allow(Vantiv).to receive(:acceptor_id).and_return "acceptor-id"
-      expect(request_body.acceptor_id).to eq "acceptor-id"
+    it "includes the merchant id" do
+      allow(Vantiv).to receive(:merchant_id).and_return "merchant-id"
+      expect(request_body.merchant_id).to eq "merchant-id"
     end
 
     it "includes the default report group" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Vantiv configuration" do
-  [:acceptor_id,
+  [:merchant_id,
    :default_report_group,
    :default_order_source,
    :paypage_id,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ Dir["#{Vantiv.root}/spec/support/**/*.rb"].each {|f| require f}
 
 Vantiv.configure do |config|
   config.environment = Vantiv::Environment::CERTIFICATION
-  config.acceptor_id = ENV["ACCEPTOR_ID"]
+  config.merchant_id = ENV["MERCHANT_ID"]
   config.default_order_source = "ecommerce"
   config.paypage_id = ENV["PAYPAGE_ID"]
 

--- a/spec/support/test_account.rb
+++ b/spec/support/test_account.rb
@@ -5,7 +5,7 @@
 #          not card data, on most transactions like auths and others.
 #       3. They do NOT provide a list of PaymentAccountIDs with each of these test accounts. They
 #          do not have a static list of them - they will be different in each merchant account
-#          (with each different Acceptor ID).
+#          (with each different Merchant ID).
 #       4. Once the PaymentAccountID is requested, it does not change - so we get it, store it,
 #          and read it in subsequent spec runs.
 #


### PR DESCRIPTION
"Acceptor Id" is specific to devhub, the XML documentation calls it a "merchant ID"